### PR TITLE
Exposing custom widgets in Grist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Automatic release
+on:
+  # Action is triggered on every commit to the master branch.
+  push:
+    branches:
+    - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build manifest
+      run: ./_build/publish.js
+      # Create new release tagged as latest, and overwrite last one.
+      # https://github.com/marvinpinto/actions/tree/master/packages/automatic-releases
+    - uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "latest"
+        prerelease: false
+        title: "Automatic release"
+        files: manifest.json

--- a/_build/publish.js
+++ b/_build/publish.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+// Creates a global manifest with all published widgets.
+
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..');
+const folders = fs.readdirSync(rootDir);
+
+function isWidgetDir(folder) {
+  const indexHtmlFile = path.join(rootDir, folder, 'index.html');
+  const packageFile = path.join(rootDir, folder, 'package.json');
+  return fs.existsSync(indexHtmlFile) && fs.existsSync(packageFile);
+}
+
+const widgets = [];
+
+for (const folder of folders) {
+  if (!fs.statSync(folder).isDirectory()) {
+    continue;
+  }
+  if (!isWidgetDir(folder)) {
+    continue;
+  }
+  const packageFile = path.join(rootDir, folder, 'package.json');
+  const packageJson = JSON.parse(fs.readFileSync(packageFile));
+  const config = packageJson.grist;
+  if (!config || !config.widgetId || !config.name || !config.url) {
+    console.debug("Package folder " + folder);
+    console.debug("Configuration " + JSON.stringify(config));
+    throw new Error(`Package in ${folder} is not configured correctly.`);
+  }
+  if (config.published) {
+    console.log('Publishing ' + config.widgetId);
+    widgets.push(config);
+  }
+}
+
+fs.writeFileSync(path.join(rootDir, 'manifest.json'), JSON.stringify(widgets, null, 2));

--- a/actionbutton/package.json
+++ b/actionbutton/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@gristlabs/widget-actionbutton",
+  "description": "actionbutton",
+  "homePage": "https://github.com/gristlabs/grist-widget",
+  "version": "0.0.1",
+  "grist": {
+    "name": "Action button",
+    "url": "https://berhalak.github.io/grist-widget/actionbutton",
+    "widgetId": "@gristlabs/widget-actionbutton",
+    "published": true
+  }
+}

--- a/actionbutton/package.json
+++ b/actionbutton/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@gristlabs/widget-actionbutton",
-  "description": "actionbutton",
+  "description": "A configurable button that can send user actions to the data engine.",
   "homePage": "https://github.com/gristlabs/grist-widget",
   "version": "0.0.1",
   "grist": {
     "name": "Action button",
-    "url": "https://berhalak.github.io/grist-widget/actionbutton",
+    "url": "https://gristlabs.github.io/grist-widget/actionbutton",
     "widgetId": "@gristlabs/widget-actionbutton",
     "published": true
   }

--- a/clipboard/package.json
+++ b/clipboard/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@gristlabs/widget-clipboard",
+  "description": "clipboard",
+  "homePage": "https://github.com/gristlabs/grist-widget",
+  "version": "0.0.1",
+  "grist": {
+    "name": "Copy to clipboard",
+    "url": "https://berhalak.github.io/grist-widget/clipboard",
+    "widgetId": "@gristlabs/widget-clipboard",
+    "published": true
+  }
+}

--- a/clipboard/package.json
+++ b/clipboard/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@gristlabs/widget-clipboard",
-  "description": "clipboard",
+  "description": "Simple widget that copies text to clipboard.",
   "homePage": "https://github.com/gristlabs/grist-widget",
   "version": "0.0.1",
   "grist": {
     "name": "Copy to clipboard",
-    "url": "https://berhalak.github.io/grist-widget/clipboard",
+    "url": "https://gristlabs.github.io/grist-widget/clipboard",
     "widgetId": "@gristlabs/widget-clipboard",
     "published": true
   }

--- a/exoplanet/package.json
+++ b/exoplanet/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@gristlabs/widget-exoplanet",
+  "description": "exoplanet",
+  "homePage": "https://github.com/gristlabs/grist-widget",
+  "version": "0.0.1",
+  "grist": {
+    "name": "Exoplanet",
+    "url": "https://berhalak.github.io/grist-widget/exoplanet",
+    "widgetId": "@gristlabs/widget-exoplanet",
+    "published": true
+  }
+}

--- a/exoplanet/package.json
+++ b/exoplanet/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@gristlabs/widget-exoplanet",
-  "description": "exoplanet",
+  "description": "Example widget that can be used to calculate age on different planets.",
   "homePage": "https://github.com/gristlabs/grist-widget",
   "version": "0.0.1",
   "grist": {
     "name": "Exoplanet",
-    "url": "https://berhalak.github.io/grist-widget/exoplanet",
+    "url": "https://gristlabs.github.io/grist-widget/exoplanet",
     "widgetId": "@gristlabs/widget-exoplanet",
     "published": true
   }

--- a/inspect/package.json
+++ b/inspect/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@gristlabs/widget-inspect",
+  "description": "inspect",
+  "homePage": "https://github.com/gristlabs/grist-widget",
+  "version": "0.0.1",
+  "grist": {
+    "name": "Inspect",
+    "url": "https://berhalak.github.io/grist-widget/inspect",
+    "widgetId": "@gristlabs/widget-inspect",
+    "published": true
+  }
+}

--- a/inspect/package.json
+++ b/inspect/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@gristlabs/widget-inspect",
-  "description": "inspect",
+  "description": "Simple widget that can be used to inspect messages sent from Grist.",
   "homePage": "https://github.com/gristlabs/grist-widget",
   "version": "0.0.1",
   "grist": {
     "name": "Inspect",
-    "url": "https://berhalak.github.io/grist-widget/inspect",
+    "url": "https://gristlabs.github.io/grist-widget/inspect",
     "widgetId": "@gristlabs/widget-inspect",
     "published": true
   }

--- a/invoices/package.json
+++ b/invoices/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@gristlabs/widget-invoices",
-  "description": "invoices",
+  "description": "A template for showing an invoice in a Custom Widget in Grist.",
   "homePage": "https://github.com/gristlabs/grist-widget",
   "version": "0.0.1",
   "grist": {
     "name": "Invoices",
-    "url": "https://berhalak.github.io/grist-widget/invoices",
+    "url": "https://gristlabs.github.io/grist-widget/invoices",
     "widgetId": "@gristlabs/widget-invoices",
     "published": true
   }

--- a/invoices/package.json
+++ b/invoices/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@gristlabs/widget-invoices",
+  "description": "invoices",
+  "homePage": "https://github.com/gristlabs/grist-widget",
+  "version": "0.0.1",
+  "grist": {
+    "name": "Invoices",
+    "url": "https://berhalak.github.io/grist-widget/invoices",
+    "widgetId": "@gristlabs/widget-invoices",
+    "published": true
+  }
+}

--- a/map/package.json
+++ b/map/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@gristlabs/widget-map",
-  "description": "map",
+  "description": "Widget for showing geolocated data on a map.",
   "homePage": "https://github.com/gristlabs/grist-widget",
   "version": "0.0.1",
   "grist": {
     "name": "Map",
-    "url": "https://berhalak.github.io/grist-widget/map",
+    "url": "https://gristlabs.github.io/grist-widget/map",
     "widgetId": "@gristlabs/widget-map",
     "published": true
   }

--- a/map/package.json
+++ b/map/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@gristlabs/widget-map",
+  "description": "map",
+  "homePage": "https://github.com/gristlabs/grist-widget",
+  "version": "0.0.1",
+  "grist": {
+    "name": "Map",
+    "url": "https://berhalak.github.io/grist-widget/map",
+    "widgetId": "@gristlabs/widget-map",
+    "published": true
+  }
+}

--- a/markdown/package.json
+++ b/markdown/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@gristlabs/widget-markdown",
+  "description": "markdown",
+  "homePage": "https://github.com/gristlabs/grist-widget",
+  "version": "0.0.1",
+  "grist": {
+    "name": "Markdown",
+    "url": "https://berhalak.github.io/grist-widget/markdown",
+    "widgetId": "@gristlabs/widget-markdown",
+    "published": true
+  }
+}

--- a/markdown/package.json
+++ b/markdown/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@gristlabs/widget-markdown",
-  "description": "markdown",
+  "description": "Markdown preview.",
   "homePage": "https://github.com/gristlabs/grist-widget",
   "version": "0.0.1",
   "grist": {
     "name": "Markdown",
-    "url": "https://berhalak.github.io/grist-widget/markdown",
+    "url": "https://gristlabs.github.io/grist-widget/markdown",
     "widgetId": "@gristlabs/widget-markdown",
     "published": true
   }

--- a/pedigree/package.json
+++ b/pedigree/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@gristlabs/widget-pedigree",
+  "description": "pedigree",
+  "homePage": "https://github.com/gristlabs/grist-widget",
+  "version": "0.0.1",
+  "grist": {
+    "name": "pedigree",
+    "url": "https://berhalak.github.io/grist-widget/pedigree",
+    "widgetId": "@gristlabs/widget-pedigree",
+    "published": false
+  }
+}

--- a/pedigree/package.json
+++ b/pedigree/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@gristlabs/widget-pedigree",
-  "description": "pedigree",
+  "description": "A widget to show animal pedigrees.",
   "homePage": "https://github.com/gristlabs/grist-widget",
   "version": "0.0.1",
   "grist": {
-    "name": "pedigree",
-    "url": "https://berhalak.github.io/grist-widget/pedigree",
+    "name": "Pedigree",
+    "url": "https://gristlabs.github.io/grist-widget/pedigree",
     "widgetId": "@gristlabs/widget-pedigree",
     "published": false
   }

--- a/printlabels/package.json
+++ b/printlabels/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@gristlabs/widget-printlabels",
+  "description": "printlabels",
+  "homePage": "https://github.com/gristlabs/grist-widget",
+  "version": "0.0.1",
+  "grist": {
+    "name": "Print labels",
+    "url": "https://berhalak.github.io/grist-widget/printlabels",
+    "widgetId": "@gristlabs/widget-printlabels",
+    "published": true
+  }
+}

--- a/printlabels/package.json
+++ b/printlabels/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@gristlabs/widget-printlabels",
-  "description": "printlabels",
+  "description": "Printable label generator.",
   "homePage": "https://github.com/gristlabs/grist-widget",
   "version": "0.0.1",
   "grist": {
     "name": "Print labels",
-    "url": "https://berhalak.github.io/grist-widget/printlabels",
+    "url": "https://gristlabs.github.io/grist-widget/printlabels",
     "widgetId": "@gristlabs/widget-printlabels",
     "published": true
   }

--- a/purchase-orders/package.json
+++ b/purchase-orders/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@gristlabs/widget-purchase-orders",
+  "description": "purchase-orders",
+  "homePage": "https://github.com/gristlabs/grist-widget",
+  "version": "0.0.1",
+  "grist": {
+    "name": "purchase-orders",
+    "url": "https://berhalak.github.io/grist-widget/purchase-orders",
+    "widgetId": "@gristlabs/widget-purchase-orders",
+    "published": false
+  }
+}

--- a/purchase-orders/package.json
+++ b/purchase-orders/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@gristlabs/widget-purchase-orders",
-  "description": "purchase-orders",
+  "description": "A template for showing a Purchase Order in a Custom Widget in Grist.",
   "homePage": "https://github.com/gristlabs/grist-widget",
   "version": "0.0.1",
   "grist": {
-    "name": "purchase-orders",
-    "url": "https://berhalak.github.io/grist-widget/purchase-orders",
+    "name": "Purchase orders",
+    "url": "https://gristlabs.github.io/grist-widget/purchase-orders",
     "widgetId": "@gristlabs/widget-purchase-orders",
     "published": false
   }

--- a/renderhtml/package.json
+++ b/renderhtml/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@gristlabs/widget-renderhtml",
-  "description": "renderhtml",
+  "description": "Simple HTML viewer.",
   "homePage": "https://github.com/gristlabs/grist-widget",
   "version": "0.0.1",
   "grist": {
     "name": "HTML viewer",
-    "url": "https://berhalak.github.io/grist-widget/renderhtml",
+    "url": "https://gristlabs.github.io/grist-widget/renderhtml",
     "widgetId": "@gristlabs/widget-renderhtml",
     "published": true
   }

--- a/renderhtml/package.json
+++ b/renderhtml/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@gristlabs/widget-renderhtml",
+  "description": "renderhtml",
+  "homePage": "https://github.com/gristlabs/grist-widget",
+  "version": "0.0.1",
+  "grist": {
+    "name": "HTML viewer",
+    "url": "https://berhalak.github.io/grist-widget/renderhtml",
+    "widgetId": "@gristlabs/widget-renderhtml",
+    "published": true
+  }
+}

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@gristlabs/widget-viewer",
-  "description": "viewer",
+  "description": "Simple image viewer for external images stored as links.",
   "homePage": "https://github.com/gristlabs/grist-widget",
   "version": "0.0.1",
   "grist": {
     "name": "Image viewer",
-    "url": "https://berhalak.github.io/grist-widget/viewer",
+    "url": "https://gristlabs.github.io/grist-widget/viewer",
     "widgetId": "@gristlabs/widget-viewer",
     "published": true
   }

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@gristlabs/widget-viewer",
+  "description": "viewer",
+  "homePage": "https://github.com/gristlabs/grist-widget",
+  "version": "0.0.1",
+  "grist": {
+    "name": "Image viewer",
+    "url": "https://berhalak.github.io/grist-widget/viewer",
+    "widgetId": "@gristlabs/widget-viewer",
+    "published": true
+  }
+}


### PR DESCRIPTION
Configuring repository as a Grist Custom Widget Repository source. Each custom widget folder was converted to a simple npm package. On every commit to master, GitHub action will create an automatic release with a single manifest file that lists all available (and published widgets) and can be used as a source of all custom widgets available in Grist. 

- Converting folders to simple npm packages
- Adding GitHub action to build manifest file for Grist.