### PR TITLE
Support URL params 'tags' (e.g. 'iframe,script') and 'attr'

### DIFF
--- a/renderhtml/index.html
+++ b/renderhtml/index.html
@@ -29,12 +29,26 @@
       var rowId = null;
       var colId = null;
       var cachedData = null;
+      var params = new URLSearchParams(window.location.search)
+      var ADD_TAGS = params.get('tags')?.split(",");
+      var ADD_ATTR = params.get('attr')?.split(",");
       function render(elemId, content) {
         var el = document.getElementById(elemId);
         if (!content) {
           el.style.display = 'none';
         } else {
-          el.innerHTML = DOMPurify.sanitize(content);
+          el.innerHTML = DOMPurify.sanitize(content, {ADD_TAGS, ADD_ATTR});
+          // If we are allowing scripts, let them execute, which doesn't
+          // normally happen when adding script elements using innerHTML.
+          if (ADD_TAGS?.includes("script")) {
+            Array.from(el.querySelectorAll("script")).forEach(oldScript => {
+              const newScript = document.createElement("script");
+              Array.from(oldScript.attributes)
+                .forEach(attr => newScript.setAttribute(attr.name, attr.value));
+              newScript.appendChild(document.createTextNode(oldScript.innerHTML));
+              oldScript.parentNode.replaceChild(newScript, oldScript);
+            });
+          }
           el.style.display = 'block';
         }
       }


### PR DESCRIPTION
These will allow the specified tags/attributes pass sanitization.
Also, if scripts are allowed, allow them to be executed.

This allows preparing more interesting HTML to render using the renderhtml widget, including things like embedding third-party sites, e.g. twitter timelines.