### PR TITLE
Updating widgets access levels.

### DIFF
--- a/actionbutton/package.json
+++ b/actionbutton/package.json
@@ -7,6 +7,7 @@
     "name": "Action button",
     "url": "https://gristlabs.github.io/grist-widget/actionbutton",
     "widgetId": "@gristlabs/widget-actionbutton",
-    "published": true
+    "published": true,
+    "accessLevel": "full"
   }
 }

--- a/clipboard/package.json
+++ b/clipboard/package.json
@@ -7,6 +7,7 @@
     "name": "Copy to clipboard",
     "url": "https://gristlabs.github.io/grist-widget/clipboard",
     "widgetId": "@gristlabs/widget-clipboard",
-    "published": true
+    "published": true,
+    "accessLevel": "read table"
   }
 }

--- a/exoplanet/package.json
+++ b/exoplanet/package.json
@@ -7,6 +7,6 @@
     "name": "Exoplanet",
     "url": "https://gristlabs.github.io/grist-widget/exoplanet",
     "widgetId": "@gristlabs/widget-exoplanet",
-    "published": true
+    "published": false
   }
 }

--- a/inspect/package.json
+++ b/inspect/package.json
@@ -7,6 +7,7 @@
     "name": "Inspect",
     "url": "https://gristlabs.github.io/grist-widget/inspect",
     "widgetId": "@gristlabs/widget-inspect",
-    "published": true
+    "published": true,
+    "accessLevel": "read table"
   }
 }

--- a/invoices/package.json
+++ b/invoices/package.json
@@ -7,6 +7,7 @@
     "name": "Invoices",
     "url": "https://gristlabs.github.io/grist-widget/invoices",
     "widgetId": "@gristlabs/widget-invoices",
-    "published": true
+    "published": true,
+    "accessLevel": "read table"
   }
 }

--- a/map/package.json
+++ b/map/package.json
@@ -7,6 +7,7 @@
     "name": "Map",
     "url": "https://gristlabs.github.io/grist-widget/map",
     "widgetId": "@gristlabs/widget-map",
-    "published": true
+    "published": true,
+    "accessLevel": "read table"
   }
 }

--- a/markdown/package.json
+++ b/markdown/package.json
@@ -7,6 +7,7 @@
     "name": "Markdown",
     "url": "https://gristlabs.github.io/grist-widget/markdown",
     "widgetId": "@gristlabs/widget-markdown",
-    "published": true
+    "published": true,
+    "accessLevel": "full"
   }
 }

--- a/pedigree/package.json
+++ b/pedigree/package.json
@@ -7,6 +7,7 @@
     "name": "Pedigree",
     "url": "https://gristlabs.github.io/grist-widget/pedigree",
     "widgetId": "@gristlabs/widget-pedigree",
-    "published": false
+    "published": false,
+    "accessLevel": "read table"
   }
 }

--- a/printlabels/package.json
+++ b/printlabels/package.json
@@ -7,6 +7,7 @@
     "name": "Print labels",
     "url": "https://gristlabs.github.io/grist-widget/printlabels",
     "widgetId": "@gristlabs/widget-printlabels",
-    "published": true
+    "published": true,
+    "accessLevel": "read table"
   }
 }

--- a/purchase-orders/package.json
+++ b/purchase-orders/package.json
@@ -7,6 +7,7 @@
     "name": "Purchase orders",
     "url": "https://gristlabs.github.io/grist-widget/purchase-orders",
     "widgetId": "@gristlabs/widget-purchase-orders",
-    "published": false
+    "published": true,
+    "accessLevel": "read table"
   }
 }

--- a/renderhtml/package.json
+++ b/renderhtml/package.json
@@ -7,6 +7,7 @@
     "name": "HTML viewer",
     "url": "https://gristlabs.github.io/grist-widget/renderhtml",
     "widgetId": "@gristlabs/widget-renderhtml",
-    "published": true
+    "published": true,
+    "accessLevel": "read table"
   }
 }

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -7,6 +7,7 @@
     "name": "Image viewer",
     "url": "https://gristlabs.github.io/grist-widget/viewer",
     "widgetId": "@gristlabs/widget-viewer",
-    "published": true
+    "published": true,
+    "accessLevel": "read table"
   }
 }


### PR DESCRIPTION
Updating widget desired access levels.
Each widget has an additional option, `accessLevel`, which Grist uses to prompt the user for permission approval.