### PR TITLE
Broken link in inspect widget landing page.

### DIFF
--- a/inspect/index.html
+++ b/inspect/index.html
@@ -8,7 +8,7 @@
     <ul>
       <li><a href="onRecord.html">onRecord</a></li>
       <li><a href="onRecords.html">onRecords</a></li>
-      <li><a href="onConfig.html">onConfig</a></li>
+      <li><a href="onOptions.html">onOptions</a></li>
     </ul>
   </body>
 </html>


### PR DESCRIPTION
Inspect widget's landing page had a broken link to the onOptions widget.