### PR TITLE
Removing Location widget. Adding options to Map widget.

### DIFF
--- a/map/index.html
+++ b/map/index.html
@@ -16,5 +16,12 @@
   <body>
     <div id="map">
     </div>
+    <div id="settings">
+      <div id="btnClose">Close</div>
+      <label id="lblToggle" for="cbxMode">
+        <input type="checkbox" id="cbxMode">
+        <span id="lblText">All locations</span>
+      </label>
+    </div>
   </body>
 </html>

--- a/map/package.json
+++ b/map/package.json
@@ -10,13 +10,6 @@
       "widgetId": "@gristlabs/widget-map#map",
       "published": true,
       "accessLevel": "read table"
-    },
-    {
-      "name": "Location",
-      "url": "https://gristlabs.github.io/grist-widget/map/index.html?mode=single",
-      "widgetId": "@gristlabs/widget-map#location",
-      "published": true,
-      "accessLevel": "read table"
     }
   ]
 }

--- a/map/screen.css
+++ b/map/screen.css
@@ -23,3 +23,28 @@ html, body, #map {
   padding: 2em;
   margin: 2em;
 }
+
+#settings {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 500;
+  padding: 10px;
+  border: 1px solid lightgray;
+  border-radius: 5px;
+  display: none;
+  background: white;
+}
+#btnClose {
+  font-size: small;
+  margin-bottom: 5px;
+  text-align: right;
+  cursor: pointer;
+}
+#btnClose:hover {
+  text-decoration: underline;
+}
+#lblText {
+  min-width: 100px;
+  display: inline-block;
+}


### PR DESCRIPTION
Currently, there are two versions of Map widget: Map and Location. The only difference was the initial mode set by the query parameter. This PR removes the Location widget and adds an option menu (available under "Open Configuration" button) to change the mode within the widget.
The query parameter is still respected (as a default mode), and the Location widget will still be visible for documents that use it, so there shouldn't be any breaking changes here.