### PR TITLE
Map: keep popup open on zoom

### DIFF
--- a/map/index.html
+++ b/map/index.html
@@ -5,9 +5,9 @@
     <script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet-src.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="screen.css" />
-    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.css" />
-    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.Default.css" />
-    <script src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
+    <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
     <!-- next line is optional - only if geocoding is desired -->
     <script src="https://unpkg.com/leaflet-control-geocoder/dist/Control.Geocoder.js"></script>
     <script src="https://docs.getgrist.com/grist-plugin-api.js"></script>


### PR DESCRIPTION
When the map is showing many locations, the selected location can be lost through clustering as the user zooms in. This adds a hacky way to keep that location open.