### PR TITLE
allow Deduction and Taxes with auto-Subtotal

### DIFF
--- a/invoices/invoice.js
+++ b/invoices/invoice.js
@@ -171,7 +171,7 @@ function updateInvoice(row) {
     if (!row.Subtotal && !row.Total && row.Items && Array.isArray(row.Items)) {
       try {
         row.Subtotal = row.Items.reduce((a, b) => a + b.Price * b.Quantity, 0);
-        row.Total = row.Subtotal;
+        row.Total = row.Subtotal + (row.Taxes || 0) - (row.Deduction || 0);
       } catch (e) {
         console.error(e);
       }


### PR DESCRIPTION
This tweaks the invoice custom widget to use Deduction and Taxes columns when the Subtotal is automatically computed. See https://github.com/gristlabs/grist-core/issues/189