### PR TITLE
Add Dropbox Embedder custom widget 

### DIFF
--- a/dropbox-embed/index.html
+++ b/dropbox-embed/index.html
@@ -13,7 +13,7 @@
         font-family: sans-serif;
         line-height: 1.4;
       }
-      ol, li, p {
+      p {
         margin: 8px 0;
       }
       #setup, #empty {

--- a/dropbox-embed/index.html
+++ b/dropbox-embed/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Dropbox Embedder</title>
+    <script src="https://docs.getgrist.com/grist-plugin-api.js"></script>
+    <script src="https://www.dropbox.com/static/api/2/dropins.js" id="dropboxjs" data-app-key="0nctenu5mmc1k5y"></script>
+    <script src="index.js"></script>
+    <style>
+      body {
+        padding: 0;
+        margin: 0;
+        font-family: sans-serif;
+        line-height: 1.4;
+      }
+      ol, li, p {
+        margin: 8px 0;
+      }
+      #setup, #empty {
+        padding: 16px;
+        display: none;
+      }
+      #dropbox {
+        height: 100vh;
+        overflow: hidden;
+        display: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="setup">
+      <p>Please select a <b><code>DROPBOX LINK</code></b> column in the creator panel.</p>
+      <p>Place <a target="_blank" href="https://help.dropbox.com/files-folders/share/view-only-access">shared links</a> to Dropbox files or folders into this column to show previews in this widget.</p>
+    </div>
+    <div id="empty">
+      <p>No Dropbox link to show.</p>
+    </div>
+    <div id="dropbox">
+    </div>
+  </body>
+</html>

--- a/dropbox-embed/index.js
+++ b/dropbox-embed/index.js
@@ -1,0 +1,44 @@
+// Alias for document.getElementById.
+const getElem = (id) => document.getElementById(id);
+
+// Show the given div ID, and hide the others on this page.
+function show(divId) {
+  for (const id of ["setup", "dropbox", "empty"]) {
+    getElem(id).style.display = (id === divId ? 'block' : 'none');
+  }
+}
+
+grist.ready({
+  columns: [
+    { name: "DropboxLink", title: 'Dropbox Link', type: 'Text'},
+  ],
+  requiredAccess: 'read table',
+});
+
+const shown = {
+  embed: null,
+  link: null,
+};
+
+function showLink(link) {
+  if (link !== shown.link) {
+    if (shown.embed) {
+      Dropbox.unmount(shown.embed);
+    }
+    shown.link = link;
+    shown.embed = link ? Dropbox.embed({link}, getElem('dropbox')) : null;
+  }
+}
+
+grist.onNewRecord(() => show("empty"));
+grist.onRecord(record => {
+  const mapped = grist.mapColumnNames(record);
+  if (!mapped) {
+    show("setup");
+  } else if (!mapped.DropboxLink) {
+    show("empty");
+  } else {
+    show("dropbox");
+    showLink(mapped.DropboxLink);
+  }
+});

--- a/dropbox-embed/index.js
+++ b/dropbox-embed/index.js
@@ -17,18 +17,27 @@ grist.ready({
   requiredAccess: 'read table',
 });
 
+const embedConfig = {
+  folder: {
+    view: 'list',
+    headerSize: 'small',
+  }
+};
+
 const shown = {
   embed: null,
   link: null,
 };
 
 function showLink(link) {
+  // Parse Grist links, i.e. "[link label] url", as for the Hyperlink widget of Text columns.
+  link = link.split(' ').pop();
   if (link !== shown.link) {
     if (shown.embed) {
       Dropbox.unmount(shown.embed);
     }
     shown.link = link;
-    shown.embed = link ? Dropbox.embed({link}, getElem('dropbox')) : null;
+    shown.embed = link ? Dropbox.embed({...embedConfig, link}, getElem('dropbox')) : null;
   }
 }
 

--- a/dropbox-embed/index.js
+++ b/dropbox-embed/index.js
@@ -1,3 +1,5 @@
+// This follows instructions in https://www.dropbox.com/developers/embedder.
+
 // Alias for document.getElementById.
 const getElem = (id) => document.getElementById(id);
 

--- a/dropbox-embed/package.json
+++ b/dropbox-embed/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@gristlabs/dropbox-embed",
+  "description": "Show interactive previews of Dropbox files or folders",
+  "homePage": "https://github.com/gristlabs/grist-widget",
+  "version": "0.0.1",
+  "grist": {
+    "name": "Dropbox Embedder",
+    "url": "https://gristlabs.github.io/grist-widget/dropbox-embed/index.html",
+    "widgetId": "@gristlabs/dropbox-embed",
+    "published": true,
+    "accessLevel": "read table"
+  }
+}


### PR DESCRIPTION
Use can place [shared links](https://help.dropbox.com/files-folders/share/view-only-access) to Dropbox files or folders into a cell, and the widget will show a preview. For example:
<img width="792" alt="Screen Shot 2022-04-23 at 12 20 09 AM" src="https://user-images.githubusercontent.com/1091143/164874967-c1ac3d52-d715-426b-91e8-d9771feed75c.png">

