### PR TITLE
Implementing onNewRecord event on viewers widgets

### DIFF
--- a/renderhtml/index.html
+++ b/renderhtml/index.html
@@ -59,6 +59,12 @@
         const columns = Object.keys(record || {}).filter(k => k !== 'id');
         return columns.length === 1 ? record[columns[0]] : undefined;
       }
+      grist.onNewRecord(() => {
+        render("error", null);
+        render("rendered", "");
+        lastData = "";
+        lastId = 0;
+      });
       grist.onRecord(function(record) {
         // If user picked all columns, this helper function will return a mapped record.
         const mapped = grist.mapColumnNames(record);
@@ -71,7 +77,7 @@
         } else {
           render("error", null);
           if (lastId !== record.id || lastData !== data) {
-            render("rendered", "" + data);
+            render("rendered", String(data || ''));
           }
           lastId = record.id;
           lastData = data;

--- a/rendervideo/index.html
+++ b/rendervideo/index.html
@@ -111,6 +111,11 @@
       const columns = Object.keys(record || {}).filter(k => k !== 'id');
       return columns.length === 1 ? record[columns[0]] : undefined;
     }
+    grist.onNewRecord(() => {
+      render("");
+      lastData = "";
+      lastId = 0;
+    });
     grist.onRecord(function(record) {
       // If user picked all columns, this helper function will return a mapped record.
       const mapped = grist.mapColumnNames(record);
@@ -122,7 +127,7 @@
         showError("Please choose a column to show in the Creator Panel.");
       } else {
         if (lastId !== record.id || lastData !== data) {
-          render("" + data);
+          render(String(data || ""));
         }
         lastId = record.id;
         lastData = data;

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -52,6 +52,10 @@
         const columns = Object.keys(record || {}).filter(k => k !== 'id');
         return columns.length === 1 ? record[columns[0]] : undefined;
       }
+      grist.onNewRecord(() => {
+        showError("");
+        viewer.style.display = 'none';
+      });
       grist.onRecord(function(record) {
         // If user picked all columns, this helper function will return a mapped record.
         const mapped = grist.mapColumnNames(record);


### PR DESCRIPTION
Viewer widgets were showing the last image/html/video when an empty record was selected. Now they handle the onNewRecord event to clear their content.