### PR TITLE
Keeping focus within Grist document when switching to an empty editor.

### DIFF
--- a/markdown/index.html
+++ b/markdown/index.html
@@ -77,7 +77,7 @@
         if (txt.isPreviewActive()) {
           txt.togglePreview();
           // Focus on the editor, but only if we have focus on the window itself,
-          // We don't want to steel focus from a table in Grist.
+          // We don't want to steal the focus from a table in Grist.
           if (!document.hasFocus()) {
             return;
           }

--- a/markdown/index.html
+++ b/markdown/index.html
@@ -76,7 +76,13 @@
         document.querySelector(".save-action").style.display = 'inline-block';
         if (txt.isPreviewActive()) {
           txt.togglePreview();
-          // We are using internals here to focus inner code editor.
+          // Focus on the editor, but only if we have focus on the window itself,
+          // We don't want to steel focus from a table in Grist.
+          if (!document.hasFocus()) {
+            return;
+          }
+          // Warning: We are using internals here to focus on the inner code editor,
+          // it might break in future easymde version.
           if (txt.codemirror && typeof txt.codemirror.focus === 'function') {
             txt.codemirror.focus();
           }


### PR DESCRIPTION
Markdown widget was stealing focus from Grist when the user switched between filled and empty rows.
This change is addressing this issue https://community.getgrist.com/t/issue-markdown-widget-stealing-focus/1450.