### PR TITLE
Improvements to the markdown widget

### DIFF
--- a/markdown/index.html
+++ b/markdown/index.html
@@ -23,6 +23,22 @@
         border-radius: 4px;
         color: black;
       }
+      blockquote {
+        border-left: 4px solid #ddd;
+        margin: 0;
+        padding: 0 1rem;
+        color: #666;
+      }
+      .editor-preview pre {
+        background-color: #eef3ff;
+        padding: 8px;
+        border-radius: 4px;
+      }
+      .editor-preview pre code {
+        background-color: unset;
+        padding: unset;
+        border-radius: unset;
+      }
       hr {
         margin-top: 2rem;
         margin-bottom: 2rem;

--- a/markdown/index.html
+++ b/markdown/index.html
@@ -43,6 +43,24 @@
         margin-top: 2rem;
         margin-bottom: 2rem;
       }
+      .editor-preview table {
+        margin: 2rem 0;
+        border-spacing: 0;
+        border: 1px solid lightgrey;
+        border-left: none;
+        border-top: none;
+      }
+      .editor-preview table th, .editor-preview table td {
+        border: 1px solid lightgrey;
+        padding: 0.5rem 1rem;
+        border-right: none;
+        border-bottom: none;
+      }
+      .editor-preview table th:empty, .editor-preview table td:empty {
+        height: 0px;
+        padding: 0px;
+        border-top: none;
+      }
       #error {
         display: none;
         background: red;
@@ -81,7 +99,23 @@
       .editor-preview {
         background: white;
       }
-      .editor-preview-full {
+      @media print {
+        html, body, textarea {
+          height: initial !important;
+        }
+        .editor-toolbar {
+          display: none !important;
+        }
+        .EasyMDEContainer {
+          height: auto !important;
+          display: block !important;
+        }
+        .EasyMDEContainer .CodeMirror-scroll {
+          display: none !important;
+        }
+        .EasyMDEContainer .editor-preview-full {
+          position: relative;
+        }
       }
     </style>
   </head>

--- a/markdown/index.html
+++ b/markdown/index.html
@@ -87,8 +87,8 @@
         top: 4px;
         right: 4px;
         z-index: 100;
-        background-color: white;
-        border: 1px solid lightgrey;
+        background-color: #ffffff80;
+        border: 1px solid #16b378;
         margin: 0;
         padding: 0;
         border-radius: 4px;

--- a/markdown/index.html
+++ b/markdown/index.html
@@ -6,190 +6,71 @@
     <script src="https://docs.getgrist.com/grist-plugin-api.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css">
     <script src="https://unpkg.com/easymde/dist/easymde.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/grainjs@1.0.2/dist/grain-full.min.js"></script>
+    <script src="index.js"></script>
     <style>
       html, body, textarea {
-          width: 100%;
-          height: 100vh;
-          padding: 0;
-          margin: 0;
+        width: 100%;
+        height: 100vh;
+        padding: 0;
+        margin: 0;
+        font-family: sans-serif;
+        line-height: 1.4;
+      }
+      code {
+        background-color: #dfe9ff;
+        padding: 0 4px;
+        border-radius: 4px;
+        color: black;
+      }
+      hr {
+        margin-top: 2rem;
+        margin-bottom: 2rem;
       }
       #error {
-          display: none;
-          background: red;
-          color: white;
-          padding: 20px;
-          text-align: center;
+        display: none;
+        background: red;
+        color: white;
+        padding: 20px;
+        text-align: center;
       }
       .editor-toolbar {
         border: none;
+        border-bottom: 1px solid #ddd;
+      }
+      .EasyMDEContainer {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
       }
       .EasyMDEContainer .CodeMirror {
         border: none;
         border-radius: 0px;
-        border-top: 1px solid #ddd;
-        border-bottom: 1px solid #ddd;
+        flex: auto;
+      }
+      .toolbar-read-mode {
+        position: absolute;
+        top: 4px;
+        right: 4px;
+        z-index: 100;
+        background-color: white;
+        border: 1px solid lightgrey;
+        margin: 0;
+        padding: 0;
+        border-radius: 4px;
+      }
+      .toolbar-read-mode > :not(.edit-action) {
+        display: none !important;
+      }
+      .editor-preview {
+        background: white;
+      }
+      .editor-preview-full {
       }
     </style>
   </head>
   <body>
     <div id="error"></div>
     <textarea id="txt"></textarea>
-    <script>
-      var tableId = null;
-      var rowId = null;
-      var colId = null;
-      var cachedData = null;
-      window.addEventListener('keypress', (ev) => {
-        // If user pressed Enter or Space
-        if (ev.keyCode === 13 || ev.keyCode === 32) {
-          // and we are in the read mode
-          if (txt.isPreviewActive()) {
-            // switch to edit mode.
-            editMode();
-            ev.preventDefault();
-            return;
-          }
-        }
-      });
-      window.addEventListener('keydown', (ev) => {
-        // If user pressed Ctrl + S
-        if (ev.key === 's' && (ev.ctrlKey || ev.metaKey)) {
-          // and in edit mode
-          if (!txt.isPreviewActive()) {
-            // save and go to read mode
-            save();
-            readMode();
-            ev.preventDefault();
-            return;
-          }
-        } else if (ev.keyCode === 27) {
-          if (!txt.isPreviewActive()) {
-            // If user pressed Escape, cancel edit
-            txt.value("" + cachedData);
-            readMode();
-            ev.preventDefault();
-          }
-        }
-      })
-      function editMode() {
-        document.querySelector(".edit-action").style.display = 'none';
-        document.querySelector(".save-action").style.display = 'inline-block';
-        if (txt.isPreviewActive()) {
-          txt.togglePreview();
-          // Focus on the editor, but only if we have focus on the window itself,
-          // We don't want to steal the focus from a table in Grist.
-          if (!document.hasFocus()) {
-            return;
-          }
-          // Warning: We are using internals here to focus on the inner code editor,
-          // it might break in future easymde version.
-          if (txt.codemirror && typeof txt.codemirror.focus === 'function') {
-            txt.codemirror.focus();
-          }
-        }
-      }
-      function readMode() {
-        document.querySelector(".edit-action").style.display = 'inline-block';
-        document.querySelector(".save-action").style.display = 'none';
-        if (!txt.isPreviewActive()) {
-          // We are using internals to release the focus.
-          if (txt.codemirror && 
-              txt.codemirror.display &&
-              txt.codemirror.display.input &&
-              typeof txt.codemirror.display.input.blur === 'function') {
-            txt.codemirror.display.input.blur();
-          }
-          txt.togglePreview();
-        }
-      }
-      var isMac = /Mac/.test(navigator.platform);
-      var txt = new EasyMDE({
-        spellChecker: false,
-        toolbar: [{
-          name: 'save',
-          action: function(editor) {
-            save();
-            readMode();
-          },
-          className: 'fa fa-save save-action',
-          title: `Save (${isMac ? 'Cmd' : 'Ctrl'} + S)`
-        },
-        {
-          name: 'edit',
-          action: function(editor) {
-            editMode();
-          },
-          className: 'fa fa-pencil edit-action',
-          title: 'Edit (Enter or Space)'
-        }, "|", "bold", "italic", "heading", "quote", "|", "link", "guide"]
-      });
-      function showError(msg) {
-        var el = document.getElementById('error')
-        if (!msg) {
-          el.style.display = 'none';
-        } else {
-          el.innerHTML = msg;
-          el.style.display = 'block';
-        }
-      }
-      function save() {
-        if (!rowId || !tableId) { return; }
-        var data = txt.value() || '';
-        if (data === cachedData) { return; }
-        console.log("SAVE", data);
-        grist.docApi.applyUserActions([ ['UpdateRecord', tableId, rowId, {
-          [colId]: data
-        }]]).then(function(e) {
-          showError(null);
-        }).catch(function(e) {
-          showError("Please grant full access for writing.");
-        });
-      }
-      grist.ready({
-        columns: [{ name: "Content", type: 'Text'}],
-        requiredAccess: 'full'
-      });
-      editMode();
-      grist.on('message', (e) => {
-        if (e.tableId) { tableId = e.tableId; }
-      });
-      grist.onRecord(function(record, mappings) {
-        save();
-        var nextRowId = record.id;
-        delete record.id;
-        var keys = Object.keys(record);
-        rowId = null;
-        colId = null;
-        if (!mappings) {
-          // We will fallback to reading a value from a single column to
-          // support old way of mapping (exposing only a single column).
-          // New widgets should only check if mappings object is truthy,
-          // or use grist.mapColumnNames helper method.
-          if (keys.length !== 1) {
-            showError("Please pick a column to store content on Creator Panel");
-            return;
-          } 
-          colId = keys[0];
-        } else if (mappings) {
-          if (!mappings.Content) {
-            showError("Please pick a column to store content on Creator Panel");
-            return;
-          }
-          colId = mappings.Content;
-        }
-        showError(null);
-        data = record[colId] || '';
-        if (nextRowId !== rowId || cachedData !== data) {
-          txt.value("" + data);
-          if (data) {
-            readMode();
-          } else {
-            editMode();
-          }
-        }
-        cachedData = data;
-        rowId = nextRowId;
-      });
-    </script>
   </body>
 </html>

--- a/markdown/index.js
+++ b/markdown/index.js
@@ -1,0 +1,195 @@
+var {dom, Observable} = grainjs;
+var tableId = null;
+var rowId = null;
+var colId = null;
+var cachedData = null;
+var txt = null;  // EasyMDE instance
+var editable = null;
+var isEditMode = Observable.create(null, false);
+
+window.addEventListener('keypress', (ev) => {
+  // If user pressed Enter or Space
+  if (ev.keyCode === 13 || ev.keyCode === 32) {
+    // and we are in the read mode
+    if (txt.isPreviewActive() && editable) {
+      // switch to edit mode.
+      editMode();
+      ev.preventDefault();
+      return;
+    }
+  }
+});
+
+window.addEventListener('keydown', (ev) => {
+  // If user pressed Ctrl + S
+  if (ev.key === 's' && (ev.ctrlKey || ev.metaKey)) {
+    // and in edit mode
+    if (!txt.isPreviewActive()) {
+      // save and go to read mode
+      save();
+      readMode();
+      ev.preventDefault();
+      return;
+    }
+  } else if (ev.keyCode === 27) {
+    if (!txt.isPreviewActive()) {
+      // If user pressed Escape, cancel edit
+      txt.value("" + cachedData);
+      readMode();
+      ev.preventDefault();
+    }
+  }
+})
+
+function editMode() {
+  isEditMode.set(true);
+  if (txt.isPreviewActive()) {
+    txt.togglePreview();
+    // Focus on the editor, but only if we have focus on the window itself,
+    // We don't want to steal the focus from a table in Grist.
+    if (!document.hasFocus()) {
+      return;
+    }
+    // Warning: We are using internals here to focus on the inner code editor,
+    // it might break in future easymde version.
+    if (txt.codemirror && typeof txt.codemirror.focus === 'function') {
+      txt.codemirror.focus();
+    }
+  }
+}
+
+function readMode() {
+  isEditMode.set(false);
+  if (!txt.isPreviewActive()) {
+    // We are using internals to release the focus.
+    if (txt.codemirror &&
+        txt.codemirror.display &&
+        txt.codemirror.display.input &&
+        typeof txt.codemirror.display.input.blur === 'function') {
+      txt.codemirror.display.input.blur();
+    }
+    txt.togglePreview();
+  }
+}
+
+function showError(msg) {
+  var el = document.getElementById('error')
+  if (!msg) {
+    el.style.display = 'none';
+  } else {
+    el.innerHTML = msg;
+    el.style.display = 'block';
+  }
+}
+
+function save() {
+  if (!editable || !rowId || !tableId) { return; }
+  var data = txt.value() || '';
+  if (data === cachedData) { return; }
+  console.log("SAVE", data);
+  grist.docApi.applyUserActions([ ['UpdateRecord', tableId, rowId, {
+    [colId]: data
+  }]]).then(function(e) {
+    showError(null);
+  }).catch(function(e) {
+    showError(String(e));
+  });
+}
+
+function ready(fn) {
+  if (document.readyState !== 'loading'){
+    fn();
+  } else {
+    document.addEventListener('DOMContentLoaded', fn);
+  }
+}
+
+var isMac = /Mac/.test(navigator.platform);
+var toolbar = [
+  {
+    name: 'save',
+    action: function(editor) {
+      save();
+      readMode();
+    },
+    className: 'fa fa-save save-action',
+    title: `Save (${isMac ? 'Cmd' : 'Ctrl'} + S)`
+  },
+  {
+    name: 'edit',
+    action: function(editor) {
+      editMode();
+    },
+    className: 'fa fa-pencil edit-action',
+    title: 'Edit (Enter or Space)'
+  },
+  "|", "bold", "italic", "heading", "quote", "|", "link", "guide",
+];
+
+ready(() => {
+  grist.ready({
+    columns: [{ name: "Content", type: 'Text'}],
+    requiredAccess: 'full'
+  });
+
+
+  grist.on('message', (e) => {
+    if (e.tableId) { tableId = e.tableId; }
+  });
+
+  grist.onOptions((options, settings) => {
+    const newEditable = (settings.accessLevel !== 'read table');
+    if (newEditable !== editable) {
+      editable = newEditable;
+      txt = new EasyMDE({
+        spellChecker: false,
+        status: false,
+        minHeight: '0px',
+        toolbar: editable ? toolbar : false,
+      });
+      if (editable) {
+        dom.update(document.querySelector(".edit-action"), dom.hide(isEditMode));
+        dom.update(document.querySelector(".save-action"), dom.show(isEditMode));
+        dom.update(txt.toolbar_div, dom.cls('toolbar-read-mode', use => !use(isEditMode)));
+      }
+    }
+  });
+
+  grist.onRecord(function(record, mappings) {
+    save();
+    var nextRowId = record.id;
+    delete record.id;
+    var keys = Object.keys(record);
+    rowId = null;
+    colId = null;
+    if (!mappings) {
+      // We will fallback to reading a value from a single column to
+      // support old way of mapping (exposing only a single column).
+      // New widgets should only check if mappings object is truthy,
+      // or use grist.mapColumnNames helper method.
+      if (keys.length !== 1) {
+        showError("Please pick a column to store content on Creator Panel");
+        return;
+      }
+      colId = keys[0];
+    } else if (mappings) {
+      if (!mappings.Content) {
+        showError("Please pick a column to store content on Creator Panel");
+        return;
+      }
+      colId = mappings.Content;
+    }
+    showError(null);
+    data = record[colId] || '';
+    if (nextRowId !== rowId || cachedData !== data) {
+      txt.value("" + data);
+      if (data) {
+        readMode();
+      } else {
+        editMode();
+      }
+    }
+    cachedData = data;
+    rowId = nextRowId;
+  });
+});


### PR DESCRIPTION
- JS code moved from index.html into a separate JS file
- Styling updated to look cleaner (more like Github's markdown styling) rather than default styles.
- Toolbar only shown in full in edit mode
- In read mode only the "edit" button is overlaid on the content, for clean rendering; and hidden when printing.
- Key behavior unchanged (Enter or Space to start editing, Cmd-S or Escape to stop)

Some previews:

Before
<img width="608" alt="Screenshot 2023-01-19 at 9 30 09 AM" src="https://user-images.githubusercontent.com/1091143/213468642-dc008e08-c28d-409e-a8e0-05353d14ed0b.png">


After
<img width="790" alt="Screenshot 2023-01-19 at 9 29 29 AM" src="https://user-images.githubusercontent.com/1091143/213468489-39bcaee5-a585-4f67-9088-b5b036032229.png">
