### PR TITLE
show progress from "1 to N" instead of "0 to N"

### DIFF
--- a/flashcards/index.js
+++ b/flashcards/index.js
@@ -43,7 +43,7 @@ function goNext(step) {
   }
   at = at % questions.length;
   ui.progressBarFilled.style.width = (at * 100 / questions.length) + "%";
-  ui.progressText.textContent = at + " of " + questions.length;
+  ui.progressText.textContent = (at + 1) + " of " + questions.length;
   const qa = questions[at];
   store.set('flashcards-at', at);
   ui.questionCard.innerHTML = qa.Question;


### PR DESCRIPTION
By showing the list index to the user, for a quiz with 10 questions, the progress bar starts at "0 of 10" and the last card shows "9 of 10", so it seems like you never get to the final card.

This changes it to start at "1 of 10" and end on "10 of 10".