### PR TITLE
show progress bar as full when on last card

### DIFF
--- a/flashcards/index.js
+++ b/flashcards/index.js
@@ -42,7 +42,7 @@ function goNext(step) {
     if (at < 0) { at = 0; }
   }
   at = at % questions.length;
-  ui.progressBarFilled.style.width = ((at + 1) * 100 / questions.length) + "%";
+  ui.progressBarFilled.style.width = (at * 100 / questions.length) + "%";
   ui.progressText.textContent = (at + 1) + " of " + questions.length;
   const qa = questions[at];
   store.set('flashcards-at', at);
@@ -53,6 +53,7 @@ function goNext(step) {
 
 function goShow() {
   setState('A');
+  ui.progressBarFilled.style.width = ((at + 1) * 100 / questions.length) + "%";
 }
 
 function setState(nextState) {

--- a/flashcards/index.js
+++ b/flashcards/index.js
@@ -42,7 +42,7 @@ function goNext(step) {
     if (at < 0) { at = 0; }
   }
   at = at % questions.length;
-  ui.progressBarFilled.style.width = (at * 100 / questions.length) + "%";
+  ui.progressBarFilled.style.width = ((at + 1) * 100 / questions.length) + "%";
   ui.progressText.textContent = (at + 1) + " of " + questions.length;
   const qa = questions[at];
   store.set('flashcards-at', at);


### PR DESCRIPTION
The previous PR fixed the text to go from 1-N instead of 0-N.

This PR fixes the progress bar so that when you're on the final card, it is 100% full.

Sorry I didn't catch it in the previous PR!