### PR TITLE
Updating css for printing in notepad widget

### DIFF
--- a/notepad/index.css
+++ b/notepad/index.css
@@ -30,3 +30,26 @@ body {
 .ql-snow .ql-picker.ql-size .ql-picker-item::before {
   content: 'Regular'
 }
+
+@media print {
+  html, body {
+    height: unset !important;
+    width: 100%;
+    margin: 0 !important;
+    padding: 0;
+    overflow: unset;
+  }
+  @page {
+    margin: 0 !important;
+  }
+  .ql-editor {
+    overflow: initial !important;
+  }
+  /* remove the scrollbars */
+  .ql-container {
+    overflow: unset !important;
+  }
+  .ql-toolbar {
+    display: none;
+  }
+}


### PR DESCRIPTION
The notepad widget with the Quill editor didn't support printing styles. This adds some basic support that should work in most cases.