### PR TITLE
Enable theme configuration for Notepad widget

### DIFF
--- a/notepad/index.css
+++ b/notepad/index.css
@@ -17,13 +17,15 @@ body {
   font-size: 13px;
 }
 
-body {
+.editor-container{
+  height: 100%;
   display: flex;
   flex-direction: column;
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif,
     Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
   overflow: hidden;
 }
+
 .ql-snow .ql-picker.ql-size .ql-picker-label::before {
   content: 'Regular'
 }

--- a/notepad/index.html
+++ b/notepad/index.html
@@ -14,7 +14,21 @@
 </head>
 
 <body>
-  <div id="editor">
+  <form id="configuration">
+    <h2>Notepad Widget Configuration</h1>
+    <div>
+      <label>Select Quill theme:
+        <select name="quillTheme" id="quillTheme">
+          <option value="snow">Snow (format via toolbar)</option>
+          <option value="bubble">Bubble (format via tooltip)</option>
+        </select>
+      </label>
+    </div>
+    <div>
+      <input type="submit" value="Save">
+    </div>
+  </form>
+  <div id="editor" class="editor-container">
   </div>
   <script src="index.js"></script>
 </body>


### PR DESCRIPTION
The default Quill theme's toolbar takes up a lot of space, so I wanted to allow selecting a different theme. The Bubble theme only shows the toolbar as a tooltip when text is selected. This PR adds a config screen where the theme can be changed.

As a side-note: this method of setting widget options seems rather clunky. Has there been any discussion about having widgets expose options directly in the sidebar?