### PR TITLE
make manifest.json available for use from browsers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+
+    - uses: actions/checkout@v3
+
     - name: Build manifest
       run: ./_build/publish.js
       # Create new release tagged as latest, and overwrite last one.
@@ -21,3 +23,14 @@ jobs:
         prerelease: false
         title: "Automatic release"
         files: manifest.json
+
+    # Would like a version of manifest.json that is usable from browsers
+    # for grist-static. CORS wildcard is not set on releases, but is set
+    # on github pages. Also jsdelivr can mirror branches, but not releases.
+    - name: Make a release branch that includes manifest.json
+      run: |
+          git config user.name "Paul's Grist Bot"
+          git config user.email "<paul+bot@getgrist.com>"
+          git add -f manifest.json
+          git commit -m "add manifest.json" -a
+          git push --set-upstream origin HEAD:release -f


### PR DESCRIPTION
It would be useful to have a copy of `manifest.json` that is usable from browsers (for grist-static). GitHub doesn't set a CORS origin wildcard for releases, but it does for GitHub Pages. Also jsdelivr can mirror branches (but not releases). So this adds a build step to make a branch that contains `master` plus the generated `manifest.json` file.