### PR TITLE
add custom widget supporting memes template

### DIFF
--- a/memes/index.html
+++ b/memes/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Grist Memes</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://docs.getgrist.com/grist-plugin-api.js"></script>
+    <script src="script.js"></script>
+  </head>
+  <body>
+    <canvas id="show">
+    </canvas>
+  </body>
+</html>

--- a/memes/script.js
+++ b/memes/script.js
@@ -1,0 +1,106 @@
+/**
+ * Scale an element to the available space.
+ */
+function scaleBasedOnWindow(elm, scale=1, fit=false){
+  if (!fit) {
+    elm.style.transform='scale('+scale/Math.min(elm.clientWidth/window.innerWidth,elm.clientHeight/window.innerHeight)+')';
+  } else{
+    elm.style.transform='scale('+scale/Math.max(elm.clientWidth/window.innerWidth,elm.clientHeight/window.innerHeight)+')';
+  }
+}
+
+/**
+ * Normalize end of line characters.
+ */
+function toMultiLine(txt){
+  txt = txt.replace(/\n\r/g, '\n');
+  txt = txt.replace(/\r\n/g, '\n');
+  return txt.split("\n");
+}
+
+/**
+ * Prepare to render meme on a canvas once the
+ * image loads.
+ */
+function setup(ctx, cvs, background, texts) {
+
+  const img1 = new Image();
+
+  img1.onload = function () {
+    cvs.width = img1.width;
+    cvs.height = img1.height;
+    scaleBasedOnWindow(cvs, 1, true);
+    ctx.drawImage(img1, 0, 0);
+    const fontScale = cvs.width / 10.0;
+    
+    for (const text of texts) {
+      const px = Math.round(fontScale * text.Size / 100.0);
+      const fontSetting = "bold " + px + "px Impact";
+      ctx.font = fontSetting;
+      ctx.textBaseline = "middle";
+      ctx.textAlign = "center";
+
+      const input = text.Text;
+      const inputs = toMultiLine(input);
+      const pad = Math.round(px/4);
+      let htotal = -pad;
+      const sizes = inputs.map(input => {
+        const box = ctx.measureText(input);
+        const w = box.width;
+        const h = box.actualBoundingBoxAscent + box.actualBoundingBoxDescent;
+        htotal += h + pad;
+        return { w, h };
+      });
+      const nlines = inputs.length;
+      const x0 = Math.round((img1.width) / 100.0 * text.Right);
+      const y0 = Math.round((img1.height) / 100.0 * (100 - text.Up));
+      if (nlines >= 1) {
+        let dy = - (htotal - sizes[0].h / 2 - sizes[nlines-1].h / 2) / 2;
+        for (let i = 0; i < nlines; i++) {
+          const line = inputs[i];
+          const size = sizes[i];
+          ctx.fillStyle = "white";
+          ctx.fillText(line, x0, y0+dy, size.w + 50);
+          ctx.fillStyle = "black";
+          ctx.strokeText(line, x0, y0+dy, size.w + 50);
+          if (i+1 < nlines) {
+            dy += size.h/2 + pad + sizes[i+1].h/2;
+          }
+        }
+      }
+    }
+  };
+
+  img1.src = background;
+}
+
+function ready(fn) {
+  if (document.readyState != 'loading'){
+    fn();
+  } else {
+    document.addEventListener('DOMContentLoaded', fn);
+  }
+}
+
+ready(function() {
+  const cvs = document.getElementById('show');
+
+  grist.ready();
+  let lastRecord = null;
+  function update(record) {
+    if (record) {
+      lastRecord = record;
+    }
+    record = lastRecord;
+    if (!record) { return; }
+    setup(cvs.getContext('2d'), cvs, record.Image, record.Texts);
+  }
+  grist.onRecord(function(record) {
+    update(record);
+  });
+
+  window.addEventListener('resize', function(event) {
+    update();
+  }, true);
+});
+

--- a/memes/style.css
+++ b/memes/style.css
@@ -1,0 +1,8 @@
+html, body, canvas {
+    margin: 0;
+    padding: 0;
+}
+
+canvas {
+    transform-origin: top left;
+}


### PR DESCRIPTION
This adds in a custom widget that was lying around in my personal fork, and got used to support a Grist template:

  https://templates.getgrist.com/gtzQwTXkgzFG/Meme-Generator

It isn't great code but it works, so just adding it unchanged other than some comments and formatting. I occasionally zap my personal fork so it would be safer not to rely on it.