### PR TITLE
Removing scrollbar, handling new record

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 manifest.json
+_build/
 
 *.swp
 *.pyc

--- a/notepad/index.css
+++ b/notepad/index.css
@@ -15,6 +15,7 @@ html,
 body {
   height: 100%;
   font-size: 13px;
+  margin: 0;
 }
 
 .editor-container{

--- a/notepad/index.html
+++ b/notepad/index.html
@@ -14,7 +14,7 @@
 </head>
 
 <body>
-  <form id="configuration">
+  <form id="configuration" style="display: none">
     <h2>Notepad Widget Configuration</h1>
     <div>
       <label>Select Quill theme:

--- a/notepad/index.js
+++ b/notepad/index.js
@@ -96,6 +96,7 @@ grist.ready({requiredAccess: 'full', columns: [{name: 'Content', type: 'Text'}],
   },
 });
 grist.onRecord(function (record, mappings) {
+  quill.enable();
   // If this is a new record, or mapping is diffrent.
   if (id !== record.id || mappings?.Content !== column) {
     id = record.id;
@@ -113,6 +114,13 @@ grist.onRecord(function (record, mappings) {
   }
 });
 
+grist.onNewRecord(function () {
+  id = null;
+  lastContent = null;
+  quill.setContents(null);
+  quill.disable();
+})
+
 // Register onOptions handler.
 grist.onOptions((customOptions, _) => {
   customOptions = customOptions || {};
@@ -129,7 +137,7 @@ saveEvent.subscribe(() => {
   // If we are in a middle of saving, skip this.
   if (lastSave) { return; }
   // If we are mapped.
-  if (column) {
+  if (column && id) {
     const content = quill.getContents();
     // Store content as json.
     const newContent = JSON.stringify(content);


### PR DESCRIPTION
The notepad widget was showing an unneeded scrollbar.
Additionally, added a `new` record handler, which clears and disables the editor.