### PR TITLE
fix for calendar break on statistic while cross-site cookies are disa…

### DIFF
--- a/calendar/page.js
+++ b/calendar/page.js
@@ -38,6 +38,7 @@ class CalendarHandler {
         taskView: false,
       },
       month: {},
+      usageStatistics: false,
       defaultView: 'week',
       template: {
         time(event) {

--- a/calendar/screen.css
+++ b/calendar/screen.css
@@ -77,5 +77,4 @@ input:checked + label{
   flex: 1;
   min-height: 600px;
   flex-shrink: 0;
-  background-color: #ff0000;
 }


### PR DESCRIPTION
…bled
*turning off 3rd part statistics, and removing that ugly red background that was showed when calendar was not-loaded 