### PR TITLE
Adding support for new record event for map and markdown widget

### DIFF
--- a/map/page.js
+++ b/map/page.js
@@ -193,6 +193,9 @@ function getInfo(rec) {
   return result;
 }
 
+// Function to clear last added markers. Used to clear the map when new record is selected.
+let clearMakers = () => {};
+
 function updateMap(data) {
   data = data || selectedRecords;
   selectedRecords = data;
@@ -282,6 +285,8 @@ function updateMap(data) {
   }
   map.addLayer(markers);
 
+  clearMakers = () => map.removeLayer(markers);
+
   try {
     map.fitBounds(new L.LatLngBounds(points), {maxZoom: 15, padding: [0, 0]});
   } catch (err) {
@@ -358,6 +363,11 @@ grist.onRecords((data, mappings) => {
     scanOnNeed(defaultMapping(data[0], mappings));
   }
 });
+
+grist.onNewRecord(() => {
+  clearMakers();
+  clearMakers = () => {};
+})
 
 function updateMode() {
   if (mode === 'single') {

--- a/markdown/index.js
+++ b/markdown/index.js
@@ -6,6 +6,7 @@ var cachedData = null;
 var txt = null;  // EasyMDE instance
 var editable = null;
 var isEditMode = Observable.create(null, false);
+let isNewRecord = Observable.create(null, true);
 
 window.addEventListener('keypress', (ev) => {
   // If user pressed Enter or Space
@@ -152,10 +153,12 @@ ready(() => {
         dom.update(document.querySelector(".save-action"), dom.show(isEditMode));
         dom.update(txt.toolbar_div, dom.cls('toolbar-read-mode', use => !use(isEditMode)));
       }
+      show(false);
     }
   });
 
   grist.onRecord(function(record, mappings) {
+    isNewRecord.set(false);
     save();
     var nextRowId = record.id;
     delete record.id;
@@ -192,4 +195,24 @@ ready(() => {
     cachedData = data;
     rowId = nextRowId;
   });
+
+  isNewRecord.addListener(isNew => {
+    toggle(!isNew);
+  });
+
+  grist.onNewRecord(() => {
+    save();
+    isNewRecord.set(true);
+    txt.value('');
+    rowId = null;
+    cachedData = data = null;
+    colId = null;
+    readMode();
+  })
+  
 });
+
+function toggle(show) {
+  txt.element.style.visibility = show ? 'visible' : 'hidden';
+  txt.toolbar_div.style.visibility = show ? 'visible' : 'hidden';
+}


### PR DESCRIPTION
Handling `onNewRecord` in map and markdown widget.