### PR TITLE
Calendar read access

### DIFF
--- a/test/declarations.d.ts
+++ b/test/declarations.d.ts
@@ -1,0 +1,28 @@
+
+declare module "selenium-webdriver" {
+  interface WebDriver {
+    withActions(cb: (actions: WebActions) => void): Promise<void>;
+  }
+
+  // This is not a complete definition of available methods, but only those that we use for now.
+  // TODO: find documentation for this interface or update selenium-webdriver.
+  interface WebActions {
+    contextClick(el?: WebElement): WebActions;
+    click(el?: WebElement): WebActions;
+    press(): WebActions;
+    move(params: {origin?: WebElement|string, x?: number, y?: number}): WebActions;
+    keyDown(key: string): WebActions;
+    keyUp(key: string): WebActions;
+    dragAndDrop(element: WebElement, target: WebElement): WebActions;
+    release(): WebActions;
+    doubleClick(element: WebElement): WebActions;
+    pause(ms: number): WebActions;
+  }
+}
+
+import "mocha-webdriver";
+declare module "mocha-webdriver" {
+  // It looks like this hack makes tsc see our definition as primary, adding
+  // the typed version override (of the withActions method) as the default one.
+  export declare let driver: import("selenium-webdriver").WebDriver;
+}

--- a/test/getGrist.ts
+++ b/test/getGrist.ts
@@ -239,6 +239,10 @@ export class GristUtils extends GristWebDriverUtils {
     await this.driver.findContent(`.test-select-menu li`, text[option]).click();
   }
 
+  public async waitForFrame() {
+    await driver.findWait("iframe.test-custom-widget-ready", 1000);
+  }
+
   public async setCustomWidgetMapping(name: string, value: string | RegExp) {
     const click = async (selector: string) => {
       try {

--- a/test/gristWebDriverUtils.ts
+++ b/test/gristWebDriverUtils.ts
@@ -246,6 +246,17 @@ export class GristWebDriverUtils {
     await this.driver.navigate().refresh();
     await this.waitForDocToLoad();
   }
+
+
+  /**
+   * Click the Undo button and wait for server. If optCount is given, click Undo that many times.
+   */
+  public async undo(optCount: number = 1, optTimeout?: number) {
+    for (let i = 0; i < optCount; ++i) {
+      await this.driver.find('.test-undo').doClick();
+    }
+    await this.waitForServer(optTimeout);
+  }
 }
 
 export interface WindowDimensions {


### PR DESCRIPTION
Checking if widget has write access. If not, disabling the calendar edit actions.
Ignoring errors from ACL, so that the days are not selected unnecessary.