### PR TITLE
[Calendar] Adding support for bi-directional linking

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "serve:dev": "live-server --port=8585 --no-browser -q --middleware=$(pwd)/buildtools/rewriteUrl.js",
     "watch": "nodemon --ignore manifest.json -e js,json --exec 'npm run build:dev'",
     "dev": "echo 'Starting local server and watching for changes.\nStart Grist with an environmental variable GRIST_WIDGET_LIST_URL=http://localhost:8585/manifest.json' && npm run watch 1> /dev/null & npm run serve:dev 1> /dev/null",
-    "test": "docker image inspect gristlabs/grist --format 'gristlabs/grist image present' && NODE_PATH=_build SELENIUM_BROWSER=chrome mocha _build/test/*.js",
+    "test": "docker image inspect gristlabs/grist --format 'gristlabs/grist image present' && NODE_PATH=_build SELENIUM_BROWSER=chrome mocha -g \"${GREP_TESTS}\" _build/test/*.js",
+    "test:ci": "MOCHA_WEBDRIVER_HEADLESS=1 npm run test",
     "pretest": "docker pull gristlabs/grist && tsc --build && node ./buildtools/publish.js http://localhost:9998"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "dev": "echo 'Starting local server and watching for changes.\nStart Grist with an environmental variable GRIST_WIDGET_LIST_URL=http://localhost:8585/manifest.json' && npm run watch 1> /dev/null & npm run serve:dev 1> /dev/null",
     "test": "docker image inspect gristlabs/grist --format 'gristlabs/grist image present' && NODE_PATH=_build SELENIUM_BROWSER=chrome mocha -g \"${GREP_TESTS}\" _build/test/*.js",
     "test:ci": "MOCHA_WEBDRIVER_HEADLESS=1 npm run test",
-    "pretest": "docker pull gristlabs/grist && tsc --build && node ./buildtools/publish.js http://localhost:9998"
+    "pretest": "docker pull gristlabs/grist && tsc --build && node ./buildtools/publish.js http://localhost:9998",
+    "grist": "docker run -t -i --rm --name grist-dev --network=host -e PORT=8484 -e GRIST_SINGLE_ORG=preview -e GRIST_WIDGET_LIST_URL=http://localhost:8585/manifest.json gristlabs/grist"
   },
   "devDependencies": {
     "@types/chai": "^4.3.5",

--- a/test/calendar.ts
+++ b/test/calendar.ts
@@ -7,8 +7,9 @@ function buildGetCalendarObjectScript(eventId: number) {
 }
 
 describe('calendar', function () {
-  this.timeout(20000);
+  this.timeout('30s');
   const grist = getGrist();
+  grist.bigScreen();
 
   async function executeAndWaitForCalendar(action: () => Promise<void>) {
     const oldDataVersion = await getDateVersion();
@@ -62,7 +63,8 @@ describe('calendar', function () {
       title: "New Event",
       startDate: new Date('2023-08-03 13:00').toJSON(),
       endDate: new Date('2023-08-03 14:00').toJSON(),
-      isAllDay: false
+      isAllDay: false,
+      selected: false
     })
   });
 
@@ -99,7 +101,8 @@ describe('calendar', function () {
       title: "New Event",
       startDate: new Date('2023-08-03 13:00').toJSON(),
       endDate: new Date('2023-08-03 15:00').toJSON(),
-      isAllDay: false
+      isAllDay: false,
+      selected: false
     })
   });
 
@@ -191,6 +194,8 @@ describe('calendar', function () {
 
     // Now try to add a record. It should fail.
     await clickDay(10);
+    await grist.waitForServer();
+    assert.equal(await eventsCount(), 0);
 
     // We don't have a good way of checking it. So we just check at the end that we have only one event..
 
@@ -201,6 +206,8 @@ describe('calendar', function () {
 
     // Now try to add a record. It should fail.
     await clickDay(11);
+    await grist.waitForServer();
+    assert.equal(await eventsCount(), 0);
 
     // Now with full access.
     await grist.setCustomWidgetAccess('full');
@@ -211,16 +218,62 @@ describe('calendar', function () {
     await grist.waitForServer();
 
     await grist.waitToPass(async () => {
-      await grist.inCustomWidget(async () => {
-        // We see only summaries (like 1 more)
-        const texts = await driver.findAll(`.toastui-calendar-weekday-grid-more-events`, g => g.getText());
-        const numbers = texts.map(t => Number(t.replace(/[^0-9]/g, '')));
-        const sum = numbers.reduce((a, b) => a + b, 0);
-        assert.equal(sum, 1);
-      });
+      assert.equal(await eventsCount(), 1);
     });
 
+    await grist.undo();
+
     // TODO: add test for ACL permissions tests and looking at document as a different user.
+  });
+
+  it("should support bi-directional linking", async function () {
+    // Make sure we have clean view
+    assert.equal(await eventsCount(), 1);
+
+    // Now configure bi-directional mapping.
+    await grist.sendActionsAndWaitForServer([
+      ['UpdateRecord', '_grist_Views_section', 1, {linkSrcSectionRef: 3}],
+      ['UpdateRecord', '_grist_Views_section', 3, {linkSrcSectionRef: 1}],
+    ]);
+
+    // Add 4 events in the calendar.
+    await clickDay(14);
+    await clickDay(15);
+    await clickDay(16);
+    await clickDay(17);
+
+    // Now test if bi-directional mapping works.
+    await grist.waitToPass(async () => {
+      assert.equal(await eventsCount(), 5);
+    });
+
+    // Select 2 row in grid view.
+    await clickRow(2);
+
+    assert.equal(await selectedRow(), 2);
+
+    // Calendar should be focues on 3rd event.
+    assert.isTrue(await getCalendarEvent(3).then(c => c.selected));
+
+    // Click 4th row
+    await clickRow(3);
+    assert.equal(await selectedRow(), 3);
+    assert.isTrue(await getCalendarEvent(4).then(c => c.selected));
+
+    // Now click on the last visible event
+    await grist.inCustomWidget(async () => {
+      const element = driver.findWait(`div[data-event-id="6"] .toastui-calendar-weekday-event-title`, 200);
+      await driver.withActions(ac =>
+        ac.move({origin: element}).press().pause(80).release()
+      );
+    });
+
+    // Grid should move to 5th row.
+    await grist.waitToPass(async () => {
+      assert.equal(await selectedRow(), 5);
+    });
+    await grist.undo(4); // Revert both changes to the view and events.
+    await grist.undo(1);
   });
 
   //Helpers
@@ -251,4 +304,20 @@ describe('calendar', function () {
     await grist.waitForServer();
   }
 
+  function eventsCount() {
+    return grist.inCustomWidget(async () => {
+      // We see only summaries (like 1 more)
+      const texts = await driver.findAll(`div[data-event-id]`, g => g.getAttribute('data-event-id'));
+      const numbers = new Set(texts.map(t => Number(t)));
+      return numbers.size;
+    });
+  }
+
+  async function clickRow(rowIndex: number) {
+    await driver.findContentWait('.gridview_data_row_num', String(rowIndex), 200).click();
+  }
+
+  async function selectedRow() {
+    return Number(await driver.findWait('.gridview_data_row_num.selected', 200).then(e => e.getText()));
+  }
 });

--- a/test/gristWebDriverUtils.ts
+++ b/test/gristWebDriverUtils.ts
@@ -257,6 +257,21 @@ export class GristWebDriverUtils {
     }
     await this.waitForServer(optTimeout);
   }
+
+
+  /**
+   * Changes browser window dimensions to FullHd for a test suite.
+   */
+  public bigScreen() {
+    let oldDimensions: WindowDimensions;
+    before(async () => {
+      oldDimensions = await this.driver.manage().window().getRect();
+      await this.driver.manage().window().setRect({width: 1920, height: 1080});
+    });
+    after(async () => {
+      await this.driver.manage().window().setRect(oldDimensions);
+    });
+  }
 }
 
 export interface WindowDimensions {


### PR DESCRIPTION
Using new `setCursor` API in the calendar widget, which will allow bi-directional linking to work.

New test was added and some updated.

https://github.com/gristlabs/grist-widget/pull/73