### PR TITLE
[Calendar] Removing redundant cursor position call

### DIFF
--- a/calendar/page.js
+++ b/calendar/page.js
@@ -190,7 +190,6 @@ class CalendarHandler {
     if (!isRecordValid(record) || this._selectedRecordId === record.id) {
       return;
     }
-    grist.setCursorPos({rowId: record.id});
     if (this._selectedRecordId) {
       this._colorCalendarEvent(this._selectedRecordId, this._mainColor);
     }


### PR DESCRIPTION
This line was not needed after all.
And since those methods are async, it is possible to click very fast to make an infinity loop.