### PR TITLE
Adding bidirectional linking to the map widget

### DIFF
--- a/map/page.js
+++ b/map/page.js
@@ -318,6 +318,7 @@ function selectMaker(id) {
      previouslyClicked.pane = 'otherMarkers';
    }
    const marker = popups[id];
+   if (!marker) { return null; }
 
    // Remember the new selected marker.
    selectedRowId = id;
@@ -380,6 +381,7 @@ grist.onRecord((record, mappings) => {
     scanOnNeed(defaultMapping(record, mappings));
   } else {
     const marker = selectMaker(record.id);
+    if (!marker) { return; }
     markers.zoomToShowLayer(marker);
     marker.openPopup();
   }


### PR DESCRIPTION
- Adding bidirectional linking to the map widget
- When map is in multi mode (shows all markers at once), it used to refresh the whole map when selected record has changed, now it is just updating the existing map