### PR TITLE
Adding strict type checking for dates and toggles

### DIFF
--- a/calendar/page.js
+++ b/calendar/page.js
@@ -438,7 +438,8 @@ function getGristOptions() {
       optional: false,
       type: "Date,DateTime",
       description: t("starting point of event"),
-      allowMultiple: false
+      allowMultiple: false,
+      strictType: true
     },
     {
       name: "endDate",
@@ -446,7 +447,8 @@ function getGristOptions() {
       optional: true,
       type: "Date,DateTime",
       description: t("ending point of event"),
-      allowMultiple: false
+      allowMultiple: false,
+      strictType: true
     },
     {
       name: "isAllDay",
@@ -454,6 +456,7 @@ function getGristOptions() {
       optional: true,
       type: "Bool",
       description: t("is event all day long"),
+      strictType: true
     },
     {
       name: "title",


### PR DESCRIPTION
Adding strict type checking for dates and toggles. As those columns can't be inferred by Grist