### PR TITLE
create a widget bundle for insertion into grist-core via npm packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "grist-widget",
-  "version": "0.0.2",
+  "name": "@gristlabs/grist-widget",
+  "version": "0.0.4",
   "description": "A repository of grist custom widgets that have no back-end requirements.",
   "scripts": {
     "build": "tsc --build && node ./buildtools/publish.js manifest.json",
@@ -12,7 +12,7 @@
     "test": "docker image inspect gristlabs/grist --format 'gristlabs/grist image present' && NODE_PATH=_build SELENIUM_BROWSER=chrome mocha -g \"${GREP_TESTS}\" _build/test/*.js",
     "test:ci": "MOCHA_WEBDRIVER_HEADLESS=1 npm run test",
     "pretest": "docker pull gristlabs/grist && tsc --build && node ./buildtools/publish.js manifest.json http://localhost:9998",
-    "bundle": "node ./buildtools/bundle.js"
+    "prepack": "node ./buildtools/bundle.js --name grist-bundled --unlisted"
   },
   "devDependencies": {
     "@types/chai": "^4.3.5",
@@ -20,6 +20,7 @@
     "@types/node": "18.11.9",
     "@types/node-fetch": "^2.6.4",
     "@types/selenium-webdriver": "^4.1.15",
+    "commander": "^11.1.0",
     "live-server": "^1.2.1",
     "mocha": "^10.2.0",
     "mocha-webdriver": "0.3.1",
@@ -33,5 +34,10 @@
     "require": [
       "_build/test/init-mocha-webdriver"
     ]
-  }
+  },
+  "files": [
+    "dist/plugins",
+    "LICENSE",
+    "README.md"
+  ]
 }

--- a/test/flashcards.ts
+++ b/test/flashcards.ts
@@ -9,7 +9,7 @@ describe('flashcards', function() {
     const docId = await grist.upload('test/fixtures/docs/SchoolsSample.grist');
     await grist.openDoc(docId);
     await grist.toggleSidePanel('right', 'open');
-    await grist.addNewSection(/Custom/, /School/);
+    await grist.addNewSection(/Custom/, /School/, {dismissTips: true});
     await grist.clickWidgetPane();
     await grist.selectCustomWidget(/Flash/);
     await grist.setCustomWidgetAccess('full');

--- a/test/inspect.ts
+++ b/test/inspect.ts
@@ -9,7 +9,7 @@ describe('inspect', function() {
     const docId = await grist.upload('test/fixtures/docs/SchoolsSample.grist');
     await grist.openDoc(docId);
     await grist.toggleSidePanel('right', 'open');
-    await grist.addNewSection(/Custom/, /School/);
+    await grist.addNewSection(/Custom/, /School/, {dismissTips: true});
     await grist.clickWidgetPane();
     await grist.selectCustomWidget('Inspect Record');
     await grist.setCustomWidgetAccess('full');

--- a/yarn.lock
+++ b/yarn.lock
@@ -528,6 +528,11 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
+  integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
+
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"


### PR DESCRIPTION
This adds a few more flags to the bundling script, and then uses them in a `prepare` script to assemble a bundle for insertion into grist-core. The bundle can be previewed as a tarball with:
```
yarn pack
```
or published to the npm registry as [@gristlabs/grist-widget](https://www.npmjs.com/package/@gristlabs/grist-widget) with:
```
yarn publish --access public
```

There will be a companion PR to grist-core to make use of the package.