### PR TITLE
Fix Invoice and Purchase Order widgets to make text visible in dark mode

### DIFF
--- a/invoices/invoice.css
+++ b/invoices/invoice.css
@@ -53,7 +53,7 @@ body {
 
 .client .details, .summary .details {
   padding: 4px;
-  background-color: var(--grist-theme-page-panels-main-panel-bg);
+  background-color: var(--grist-theme-page-panels-main-panel-bg, white);
 }
 
 table.items {
@@ -71,7 +71,7 @@ table.items th {
 }
 
 table.items td {
-  background-color: var(--grist-theme-page-panels-main-panel-bg);
+  background-color: var(--grist-theme-page-panels-main-panel-bg, white);
   padding: 4px;
 }
 

--- a/purchase-orders/purchase_order.css
+++ b/purchase-orders/purchase_order.css
@@ -56,7 +56,7 @@ body {
 
 .vendor .details {
   padding: 4px;
-  background-color: var(--grist-theme-page-panels-main-panel-bg);
+  background-color: var(--grist-theme-page-panels-main-panel-bg, white);
 }
 
 table.items {
@@ -74,7 +74,7 @@ table.items th {
 }
 
 table.items td {
-  background-color: var(--grist-theme-page-panels-main-panel-bg);
+  background-color: var(--grist-theme-page-panels-main-panel-bg, white);
   padding: 4px;
 }
 


### PR DESCRIPTION
CSS tweaks. Light mode looks the same as before the change.

Dark mode before:
<img width="485" alt="Screenshot 2023-11-14 at 12 06 51 PM" src="https://github.com/gristlabs/grist-widget/assets/1091143/adc4320e-3666-46bf-9474-8ef4abbdbc72">
<img width="487" alt="Screenshot 2023-11-14 at 12 07 11 PM" src="https://github.com/gristlabs/grist-widget/assets/1091143/bb8cdc29-7970-4846-8e59-b2d2bfb8e17d">

Dark mode after:
<img width="485" alt="Screenshot 2023-11-14 at 12 06 15 PM" src="https://github.com/gristlabs/grist-widget/assets/1091143/a247034e-80d3-41d0-bd5d-1616c26b65e4">
<img width="486" alt="Screenshot 2023-11-14 at 12 06 26 PM" src="https://github.com/gristlabs/grist-widget/assets/1091143/036aa590-566a-4c87-848b-00687550fce3">
