### PR TITLE
Ensure manifest urls don't redirect

### DIFF
--- a/exoplanet/package.json
+++ b/exoplanet/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.1",
   "grist": {
     "name": "Exoplanet",
-    "url": "https://gristlabs.github.io/grist-widget/exoplanet",
+    "url": "https://gristlabs.github.io/grist-widget/exoplanet/index.html",
     "widgetId": "@gristlabs/widget-exoplanet",
     "published": false,
     "renderAfterReady": true

--- a/invoices/package.json
+++ b/invoices/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.1",
   "grist": {
     "name": "Invoices",
-    "url": "https://gristlabs.github.io/grist-widget/invoices",
+    "url": "https://gristlabs.github.io/grist-widget/invoices/index.html",
     "widgetId": "@gristlabs/widget-invoices",
     "published": true,
     "accessLevel": "read table",

--- a/markdown/package.json
+++ b/markdown/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.1",
   "grist": {
     "name": "Markdown",
-    "url": "https://gristlabs.github.io/grist-widget/markdown",
+    "url": "https://gristlabs.github.io/grist-widget/markdown/index.html",
     "widgetId": "@gristlabs/widget-markdown",
     "published": true,
     "accessLevel": "full",

--- a/notepad/package.json
+++ b/notepad/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.1",
   "grist": {
     "name": "Notepad",
-    "url": "https://gristlabs.github.io/grist-widget/notepad",
+    "url": "https://gristlabs.github.io/grist-widget/notepad/index.html",
     "widgetId": "@gristlabs/widget-notepad",
     "published": true,
     "accessLevel": "full",

--- a/pedigree/package.json
+++ b/pedigree/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.1",
   "grist": {
     "name": "Pedigree",
-    "url": "https://gristlabs.github.io/grist-widget/pedigree",
+    "url": "https://gristlabs.github.io/grist-widget/pedigree/index.html",
     "widgetId": "@gristlabs/widget-pedigree",
     "published": false,
     "accessLevel": "read table",

--- a/purchase-orders/package.json
+++ b/purchase-orders/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.1",
   "grist": {
     "name": "Purchase orders",
-    "url": "https://gristlabs.github.io/grist-widget/purchase-orders",
+    "url": "https://gristlabs.github.io/grist-widget/purchase-orders/index.html",
     "widgetId": "@gristlabs/widget-purchase-orders",
     "published": true,
     "accessLevel": "read table",


### PR DESCRIPTION
Because the current URLs don't have a trailing slash, they get instantly redirected, e.g. https://gristlabs.github.io/grist-widget/invoices is redirected to https://gristlabs.github.io/grist-widget/invoices/. On GitHub pages this is actually fine, but when the dev server does the equivalent redirect it also removes query params, potentially causing confusing bugs in local development.

This isn't currently a concern since none of these widgets use the query params provided by Grist such as `access` or `timeZone`. I mostly just want to highlight this so that future widgets consistently use a redirect-free URL.

This can only be merged safely if we can guarantee that changing a URL in the manifest won't clear widget settings in existing documents (via changing the URL of the widget) and I'm not sure if it's worth the effort to ensure that right now.

The trailing `index.html` in each URL is probably not needed but I wanted to be consistent with other widgets.