### PR TITLE
Open Record Card on Calendar event click

### DIFF
--- a/calendar/page.js
+++ b/calendar/page.js
@@ -218,6 +218,7 @@ class CalendarHandler {
     TZDate = this.calendar.getDate().constructor;
 
     this.calendar.on('clickEvent', async (info) => {
+      focusWidget();
       await grist.setCursorPos({rowId: info.event.id});
     });
 
@@ -843,10 +844,11 @@ function clean(obj) {
   return Object.fromEntries(Object.entries(obj).filter(([k, v]) => v !== undefined));
 }
 
-// HACK: show detail popup on dblclick instead of single click.
-document.addEventListener('dblclick', (ev) => {
-  // tui calendar shows this popup on mouseup, so there is no way to customize it.
-  // So we turn it off (by leaving useDetailPopup to false), and show this popup ourselves.
+// HACK: show Record Card popup on dblclick.
+document.addEventListener('dblclick', async (ev) => {
+  // tui calendar shows a popup on mouseup, and there is no way to customize it.
+  // So we turn it off (by leaving useDetailPopup to false), and show the Record Card
+  // popup ourselves.
 
   // Code that I read to make it happen:
   //
@@ -876,9 +878,7 @@ document.addEventListener('dblclick', (ev) => {
   const event = calendarHandler.calendar.getEventModel(eventId, CALENDAR_NAME);
   if (!event) { return; }
 
-  // Now show the popup the same way as in the code above.
-  const store = calendarHandler.calendar.getStoreDispatchers('popup');
-  // This parameter was picked by hand (with try and fail method).
-  const eventRect = eventDom.getBoundingClientRect();
-  store.showDetailPopup({event, eventRect}, false);
+  // Now show the Record Card popup.
+  await grist.setCursorPos({rowId: event.id});
+  await grist.commandApi.run('viewAsCard');
 });

--- a/test/calendar.ts
+++ b/test/calendar.ts
@@ -304,6 +304,22 @@ describe('calendar', function () {
     await grist.undo(1);
   });
 
+  it("should show Record Card popup on double click", async function () {
+    await createCalendarEvent(18, 'TestRecordCard');
+    await grist.inCustomWidget(async () => {
+      const event = driver.findContentWait('.toastui-calendar-weekday-event-title', /TestRecordCard/, 1000);
+      await driver.withActions(a => a.doubleClick(event));
+    });
+    assert.isTrue(await driver.findWait('.test-record-card-popup-overlay', 1000).isDisplayed());
+    assert.equal(
+      await driver.find('.test-record-card-popup-wrapper .test-widget-title-text').getText(),
+      'TABLE1 Card'
+    );
+    assert.isTrue(await driver.findContent('.g_record_detail_value', 'TestRecordCard').isPresent());
+    await driver.sendKeys(Key.ESCAPE);
+    assert.isFalse(await driver.find('.test-record-card-popup-overlay').isPresent());
+  });
+
   //Helpers
   async function selectPerspective(perspective: 'month' | 'week' | 'day') {
     await grist.inCustomWidget(async () => {
@@ -338,22 +354,6 @@ describe('calendar', function () {
       await switchLanguage('English');
       await assertTodayButtonText('today');
     }
-  });
-
-  it("should show Record Card popup on double click", async function () {
-    await selectPerspective('month');
-    await navigateCalendar('today');
-    await createCalendarEvent(18, 'TestRecordCard');
-    await grist.inCustomWidget(async () => {
-      const event = driver.findContentWait('.toastui-calendar-weekday-event-title', /TestRecordCard/, 1000);
-      await driver.withActions(a => a.doubleClick(event));
-    });
-    assert.isTrue(await driver.findWait('.test-record-card-popup-overlay', 1000).isDisplayed());
-    assert.equal(
-      await driver.find('.test-record-card-popup-wrapper .test-widget-title-text').getText(),
-      'TABLE1 Card'
-    );
-    assert.isTrue(await driver.findContent('.g_record_detail_value', 'TestRecordCard').isPresent());
   });
 
   // TODO: test adding new events and moving existing one on the calendar.

--- a/test/calendar.ts
+++ b/test/calendar.ts
@@ -341,6 +341,24 @@ describe('calendar', function () {
     }
   });
 
+  it("should show Record Card popup on double click", async function () {
+    await selectPerspective('month');
+    await navigateCalendar('today');
+    await createCalendarEvent(18, 'TestRecordCard');
+    await grist.inCustomWidget(async () => {
+      const event = driver.findWait(`div[data-event-id="3"] .toastui-calendar-weekday-event-title`, 200);
+      await driver.withActions(ac =>
+        ac.move({origin: event}).press().pause(100).release().pause(100).press().pause(100).release()
+      );
+    });
+    assert.isTrue(await driver.findWait('.test-record-card-popup-overlay', 100).isDisplayed());
+    assert.equal(
+      await driver.find('.test-record-card-popup-wrapper .test-widget-title-text').getText(),
+      'TABLE1 Card'
+    );
+    assert.isTrue(await driver.findContent('.g_record_detail_value', 'TestRecordCard').isPresent());
+  });
+
   // TODO: test adding new events and moving existing one on the calendar.
   // ToastUI is not best optimized for drag and drop tests in mocha and I cannot yet make it work correctly.
 

--- a/test/calendar.ts
+++ b/test/calendar.ts
@@ -347,11 +347,9 @@ describe('calendar', function () {
     await createCalendarEvent(18, 'TestRecordCard');
     await grist.inCustomWidget(async () => {
       const event = driver.findWait(`div[data-event-id="3"] .toastui-calendar-weekday-event-title`, 200);
-      await driver.withActions(ac =>
-        ac.move({origin: event}).press().pause(100).release().pause(100).press().pause(100).release()
-      );
+      await driver.withActions(a => a.doubleClick(event));
     });
-    assert.isTrue(await driver.findWait('.test-record-card-popup-overlay', 100).isDisplayed());
+    assert.isTrue(await driver.findWait('.test-record-card-popup-overlay', 200).isDisplayed());
     assert.equal(
       await driver.find('.test-record-card-popup-wrapper .test-widget-title-text').getText(),
       'TABLE1 Card'

--- a/test/calendar.ts
+++ b/test/calendar.ts
@@ -245,7 +245,6 @@ describe('calendar', function () {
     await grist.waitForFrame();
 
     await createCalendarEvent(12, 'Test1');
-    await grist.waitForServer();
     await grist.waitToPass(async () => {
       assert.equal(await eventsCount(), 1);
     });
@@ -346,10 +345,10 @@ describe('calendar', function () {
     await navigateCalendar('today');
     await createCalendarEvent(18, 'TestRecordCard');
     await grist.inCustomWidget(async () => {
-      const event = driver.findWait(`div[data-event-id="3"] .toastui-calendar-weekday-event-title`, 200);
+      const event = driver.findWait(`div[data-event-id="3"] .toastui-calendar-weekday-event-title`, 1000);
       await driver.withActions(a => a.doubleClick(event));
     });
-    assert.isTrue(await driver.findWait('.test-record-card-popup-overlay', 200).isDisplayed());
+    assert.isTrue(await driver.findWait('.test-record-card-popup-overlay', 1000).isDisplayed());
     assert.equal(
       await driver.find('.test-record-card-popup-wrapper .test-widget-title-text').getText(),
       'TABLE1 Card'

--- a/test/calendar.ts
+++ b/test/calendar.ts
@@ -345,7 +345,7 @@ describe('calendar', function () {
     await navigateCalendar('today');
     await createCalendarEvent(18, 'TestRecordCard');
     await grist.inCustomWidget(async () => {
-      const event = driver.findWait(`div[data-event-id="3"] .toastui-calendar-weekday-event-title`, 1000);
+      const event = driver.findContentWait('.toastui-calendar-weekday-event-title', /TestRecordCard/, 1000);
       await driver.withActions(a => a.doubleClick(event));
     });
     assert.isTrue(await driver.findWait('.test-record-card-popup-overlay', 1000).isDisplayed());


### PR DESCRIPTION
New test will fail temporarily until the Grist image is updated with support for opening a Record Card from a custom widget.