### PR TITLE
Add optional HTML export to Notepad widget

### DIFF
--- a/notepad/index.html
+++ b/notepad/index.html
@@ -5,9 +5,9 @@
   <meta charset="utf-8">
   <title>Notepad</title>
   <script src="https://docs.getgrist.com/grist-plugin-api.js"></script>
-  <link href="//cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
-  <link href="//cdn.quilljs.com/1.3.6/quill.bubble.css" rel="stylesheet">
-  <script src="//cdn.quilljs.com/1.3.6/quill.min.js"></script>
+  <link href="https://cdn.jsdelivr.net/npm/quill@2.0.2/dist/quill.snow.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/quill@2.0.2/dist/quill.bubble.css" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/quill@2.0.2/dist/quill.js"></script>
   <link href="index.css" rel="stylesheet">
   <script src="https://unpkg.com/rxjs@%5E7/dist/bundles/rxjs.umd.min.js"></script>
   <script src="image-resize.min.js"></script>

--- a/notepad/index.js
+++ b/notepad/index.js
@@ -29,6 +29,7 @@ let quill = {};
 
 const textChanged = new Subject();
 let column;
+let exportColumn;
 let id;
 let lastContent;
 let lastSave;
@@ -91,7 +92,7 @@ async function saveOptions() {
 }
 
 // Subscribe to grist data
-grist.ready({requiredAccess: 'full', columns: [{name: 'Content', type: 'Text'}],
+grist.ready({requiredAccess: 'full', columns: [{name: 'Content', type: 'Text'}, {name: 'HTML', type: 'Text', optional: true}],
   // Register configuration handler to show configuration panel.
   onEditOptions() {
     showPanel('configuration');
@@ -103,6 +104,7 @@ grist.onRecord(function (record, mappings) {
   if (id !== record.id || mappings?.Content !== column) {
     id = record.id;
     column = mappings?.Content;
+    exportColumn = mappings?.HTML;
     const mapped = grist.mapColumnNames(record);
     if (!mapped) {
       // Log but don't bother user - maybe we are just testing.
@@ -150,6 +152,7 @@ saveEvent.subscribe(() => {
     lastContent = newContent;
     lastSave = table.update({id, fields: {
       [column]: lastContent,
+      ...(exportColumn ? {[exportColumn]: quill.getSemanticHTML()}: {}),
     }}).finally(() => lastSave = null);
   }
 });

--- a/notepad/index.js
+++ b/notepad/index.js
@@ -104,7 +104,6 @@ grist.onRecord(function (record, mappings) {
   if (id !== record.id || mappings?.Content !== column) {
     id = record.id;
     column = mappings?.Content;
-    exportColumn = mappings?.HTML;
     const mapped = grist.mapColumnNames(record);
     if (!mapped) {
       // Log but don't bother user - maybe we are just testing.
@@ -116,6 +115,7 @@ grist.onRecord(function (record, mappings) {
       quill.setContents(content);
     }
   }
+  exportColumn = mappings?.HTML;
 });
 
 grist.onNewRecord(function () {


### PR DESCRIPTION
Hi,


My attempt to fix #128 .

Working deployment on https://guillett.github.io/grist-widget/ (notepad only)