### PR TITLE
Fixes Calendar not working offline

### DIFF
--- a/calendar/package.json
+++ b/calendar/package.json
@@ -12,7 +12,7 @@
       "accessLevel": "full",
       "renderAfterReady": true,
       "archive": {
-        "domains": ["uicdn.toast.com", "maxcdn.bootstrapcdn.com"],
+        "domains": ["uicdn.toast.com", "maxcdn.bootstrapcdn.com", "unpkg.com", "cdn.jsdelivr.net"],
         "entrypoints": [
           "https://gristlabs.github.io/grist-widget/calendar/i18n/"
         ]


### PR DESCRIPTION
The calendar widget currently doesn't work in Grist Desktop, due to it trying to fetch certain dependencies from the internet.

This PR adds those dependencies to the bundle, enabling offline use.


## Testing

This change was tested locally by producing a new bundle and rebuilding Grist Desktop.