### PR TITLE
editor: Fixing bug that caused infinite loop during preview

### DIFF
--- a/custom-widget-builder/api.js
+++ b/custom-widget-builder/api.js
@@ -385,7 +385,7 @@ window.addEventListener('message', e => {
     ) {
       e.data.args ??= [{}];
       e.data.args[0].hasCustomOptions = true;
-      // Here is the trick part. Inner widget is calling ready method and configure method (as
+      // Here is the tricky part. Inner widget is calling ready method and configure method (as
       // part of grist.ready() call). Since we don't call configure method at all, we just append
       // the `hasCustomOptions` to the configure method, and send it back to Grist. This way Grist
       // will receive same configuration of mapping columns each time, which will avoid the infinite

--- a/custom-widget-builder/api.js
+++ b/custom-widget-builder/api.js
@@ -393,7 +393,7 @@ window.addEventListener('message', e => {
     }
     window.parent.postMessage(e.data, '*');
   } else if (e.source === window.parent) {
-    // If user clicks `Open confirguration` button, we will switch to the editor.
+    // If user clicks `Open configuration` button, we will switch to the editor.
     // The message that we will receive is:
     // {"mtype":1,"reqId":6,"iface":"editOptions","meth":"invoke","args":[]}
     if (e.data?.iface === 'editOptions' && e.data?.meth === 'invoke') {

--- a/custom-widget-builder/index.html
+++ b/custom-widget-builder/index.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8">
   <title>Grist Fiddle</title>
   <script src="https://docs.getgrist.com/grist-plugin-api.js"></script>
-  <script src="api_deps.js"></script>
   <style>
     #page_widget {
       flex: 1;


### PR DESCRIPTION
When an inner widget was reporting some mandatory columns to map, the builder was causing infinite loop. More in comment, but here is summary.
- Builder was sending ready message to Grist, without any mapped columns
- Grist was rendering the widget, sending JS/HTML back
- Builder was creating inner widget, which called ready method and reported some mandatory columns to map
- Grist unloads builder, as columns where not mapped
- User mapped a column
- Grist loads builder
- Builder reports back to Grist that no columns to map (and no mandatory columns anymore). 
- Grist unloads builder once again (as mandatory option has changed, and Grist is sensitive here).
- Grist sees no mandatory columns, so shows builder once again.
- Builder, reports back no mandatory columns, creates inner widget, this inner widget reports mandatory columns
- And it loops

Here the basic idea was not to call the `configure` endpoint from the builder, instead builder is injecting its configuration in the `configure` call from the inner widget, that way Grist sees only one configure call, and columns mapping stays consistent during reloads.

Not related:
- Some dead code is removed
- api_deps.js is loaded with monaco
- moncaco scripts are loaded in parallel 

Here is a document with this builder and markdown widget's content inside (with mandatory column):
https://public.getgrist.com/d1t1x4BvxuMK/JsFiddle