### PR TITLE
Fix geocoder to new 3.x API

### DIFF
--- a/map/page.js
+++ b/map/page.js
@@ -103,18 +103,14 @@ if (URLSearchParams && location.search && geocoder) {
 }
 
 async function geocode(address) {
-  return new Promise((resolve, reject) => {
-    try {
-      geocoder.geocode(address, (v) => {
-        v = v[0];
-        if (v) { v = v.center; }
-        resolve(v);
-      });
-    } catch (e) {
-      console.log("Problem:", e);
-      reject(e);
-    }
-  });
+  const results = await geocoder.geocode(address);
+  let v = results[0];
+
+  if (v) {
+    v = v.center;
+  }
+
+  return v;
 }
 
 async function delay(ms) {


### PR DESCRIPTION
As index.html is using the latest version of leaflet-control-geocoder and the API changed in 3.0.0 with this example:

```diff
Migrate from callbacks to Promise

-geocoder.geocode(query, callback);
+geocoder.geocode(query).then(callback);

-geocoder.reverse(latlng, scale, callback);
+geocoder.reverse(latlng, scale).then(callback);

Migrate from callbacks to async-await

-geocoder.geocode(query, callback);
+const results = await geocoder.geocode(query);

-geocoder.reverse(latlng, scale, callback);
+const results = await geocoder.reverse(latlng, scale);
```

The usage in the map widget also needs updating to correspond.