### PR TITLE
tests: restore gristWebDriverUtils from grist-core

### DIFF
--- a/test/app/README.md
+++ b/test/app/README.md
@@ -1,0 +1,1 @@
+This directory is here only for the sake of tests, to provide some stub imports.

--- a/test/app/client/components/commandList.ts
+++ b/test/app/client/components/commandList.ts
@@ -1,0 +1,1 @@
+export type CommandName = any;

--- a/test/app/common/DocActions.ts
+++ b/test/app/common/DocActions.ts
@@ -1,0 +1,2 @@
+export type DocAction = any;
+export type UserAction = any;

--- a/test/calendar.ts
+++ b/test/calendar.ts
@@ -83,7 +83,7 @@ describe('calendar', function () {
 
   it('should create new event when new row is added', async function () {
     await executeAndWaitForCalendar(async () => {
-      await grist.sendActionsAndWaitForServer([['AddRecord', 'Table1', -1, {
+      await grist.sendActions([['AddRecord', 'Table1', -1, {
         From: new Date('2023-08-03 13:00'),
         To: new Date('2023-08-03 14:00'),
         Label: "New Event",
@@ -101,7 +101,7 @@ describe('calendar', function () {
 
   it('should create new all day event when new row is added', async function () {
     await executeAndWaitForCalendar(async () => {
-      await grist.sendActionsAndWaitForServer([['AddRecord', 'Table1', -1, {
+      await grist.sendActions([['AddRecord', 'Table1', -1, {
         From: new Date('2023-08-04 13:00'),
         To: new Date('2023-08-04 14:00'),
         Label: "All Day Event",
@@ -120,7 +120,7 @@ describe('calendar', function () {
 
   it('should update event when table data is changed', async function () {
     await executeAndWaitForCalendar(async () => {
-      await grist.sendActionsAndWaitForServer([['UpdateRecord', 'Table1', 1, {
+      await grist.sendActions([['UpdateRecord', 'Table1', 1, {
         From: new Date('2023-08-03 13:00'),
         To: new Date('2023-08-03 15:00'),
         Label: "New Event",
@@ -138,7 +138,7 @@ describe('calendar', function () {
 
   it('should remove event when row is deleted', async function () {
     await executeAndWaitForCalendar(async () => {
-      await grist.sendActionsAndWaitForServer([['RemoveRecord', 'Table1', 1]]);
+      await grist.sendActions([['RemoveRecord', 'Table1', 1]]);
     });
     const mappedObject = await getCalendarEvent(1)
     assert.isNull(mappedObject);
@@ -269,7 +269,7 @@ describe('calendar', function () {
     assert.equal(await eventsCount(), 1);
 
     // Now configure bi-directional mapping.
-    await grist.sendActionsAndWaitForServer([
+    await grist.sendActions([
       ['UpdateRecord', '_grist_Views_section', 1, {linkSrcSectionRef: 4}],
       ['UpdateRecord', '_grist_Views_section', 4, {linkSrcSectionRef: 1}],
     ]);

--- a/test/getGrist.ts
+++ b/test/getGrist.ts
@@ -4,10 +4,8 @@ import fs from 'fs';
 import { driver, enableDebugCapture } from 'mocha-webdriver';
 import fetch from 'node-fetch';
 
-import {GristWebDriverUtils} from 'test/gristWebDriverUtils';
-
-
-
+import {Key} from 'mocha-webdriver';
+import {GristWebDriverUtils} from "test/gristWebDriverUtils";
 
 /**
  * Set up mocha hooks for starting and stopping Grist. Return
@@ -284,5 +282,39 @@ export class GristUtils extends GristWebDriverUtils {
     return this.inCustomWidget(() => {
       return driver.executeScript(script, ...args);
     })
+  }
+
+  public async login() {
+    //just click log in to get example account.
+    const menu = await this.driver.findWait('.test-dm-account', 1000);
+    await menu.click();
+    if (await this.isAlertShown()) {
+      await this.acceptAlert();
+    }
+    await this.waitForServer();
+  }
+
+  public async addColumn(table: string, name: string) {
+    // focus on table
+    await this.selectSectionByTitle(table);
+    // add new column using a shortcut
+    await this.driver.actions().keyDown(Key.ALT).sendKeys('=').keyUp(Key.ALT).perform();
+    // wait for rename panel to show up
+    await this.driver.findWait('.test-column-title-popup', 1000);
+    // rename and accept
+    await this.driver.sendKeys(name);
+    await this.driver.sendKeys(Key.ENTER);
+    await this.waitForServer();
+  }
+
+  public async focusOnCell(columnName: string, row: number) {
+    const cell = await this.getCell({ col: columnName, rowNum: row });
+    await cell.click();
+  }
+
+  public async fillCell(columnName: string, row: number, value: string) {
+    await this.focusOnCell(columnName, row);
+    await this.driver.sendKeys(value)
+    await this.driver.sendKeys(Key.ENTER);
   }
 }

--- a/test/gristWebDriverUtils.ts
+++ b/test/gristWebDriverUtils.ts
@@ -8,17 +8,21 @@
  * easily.
  */
 
-import { Key, WebDriver, WebElement, WebElementPromise } from 'mocha-webdriver';
 import escapeRegExp = require('lodash/escapeRegExp');
+import { CommandName } from 'app/client/components/commandList';
+import { DocAction, UserAction } from 'app/common/DocActions';
+import { WebDriver, WebElement, WebElementPromise } from 'mocha-webdriver';
 
-type SectionTypes = 'Table' | 'Card' | 'Card List' | 'Chart' | 'Custom';
-type UserAction = Array<string | number | object | boolean | null | undefined>;
+type SectionTypes = 'Table'|'Card'|'Card List'|'Chart'|'Custom'|'Form';
+
+// it is sometimes useful in debugging to turn off automatic cleanup of docs and workspaces.
+export const noCleanup = Boolean(process.env.NO_CLEANUP);
 
 export class GristWebDriverUtils {
   public constructor(public driver: WebDriver) {
   }
 
-  public isSidePanelOpen(which: 'right' | 'left'): Promise<boolean> {
+  public isSidePanelOpen(which: 'right'|'left'): Promise<boolean> {
     return this.driver.find(`.test-${which}-panel`).matches('[class*=-open]');
   }
 
@@ -28,61 +32,26 @@ export class GristWebDriverUtils {
    *
    * Simply call this after some request has been made, and when it resolves, you know that request
    * has been processed.
-   * @param optTimeout: Timeout in ms, defaults to 2000.
+   * @param optTimeout: Timeout in ms, defaults to 5000.
    */
-  public async waitForServer(optTimeout: number = 2000) {
+  public async waitForServer(optTimeout: number = 5000) {
     await this.driver.wait(() => this.driver.executeScript(
       "return window.gristApp && (!window.gristApp.comm || !window.gristApp.comm.hasActiveRequests())"
-      + " && window.gristApp.testNumPendingApiRequests() === 0",
+        + " && window.gristApp.testNumPendingApiRequests() === 0"
+      )
+      // The catch is in case executeScript() fails. This is rare but happens occasionally when
+      // browser is busy (e.g. sorting) and doesn't respond quickly enough. The timeout selenium
+      // allows for a response is short (and I see no place to configure it); by catching, we'll
+      // let the call fail until our intended timeout expires.
+      .catch((e) => { console.log("Ignoring executeScript error", String(e)); }),
       optTimeout,
       "Timed out waiting for server requests to complete"
-    ));
-  }
-
-  public async sendActionsAndWaitForServer(actions: UserAction[], optTimeout: number = 2000) {
-    const result = await this.driver.executeAsyncScript(async (actions: any, done: Function) => {
-      try {
-        await (window as any).gristDocPageModel.gristDoc.get().docModel.docData.sendActions(actions);
-        done(null);
-      } catch (err) {
-        done(String(err?.message || err));
-      }
-    }, actions);
-    if (result) {
-      throw new Error(result as string);
-    }
-    await this.waitForServer(optTimeout);
-  }
-
-  /**
- * Runs a Grist command in the browser window.
- */
-  public async sendCommand(name: string, argument: any = null) {
-    await this.driver.executeAsyncScript((name: any, argument: any, done: any) => {
-      const result = (window as any).gristApp.allCommands[name].run(argument);
-      if (result?.finally) {
-        result.finally(done);
-      } else {
-        done();
-      }
-    }, name, argument);
-    await this.waitForServer();
-  }
-
-
-  public async login() {
-    //just click log in to get example account.
-    const menu = await this.driver.findWait('.test-dm-account', 1000);
-    await menu.click();
-    if (await this.isAlertShown()) {
-      await this.acceptAlert();
-    }
-    await this.waitForServer();
+    );
   }
 
   public async waitForSidePanel() {
     // 0.4 is the duration of the transition setup in app/client/ui/PagePanels.ts for opening the
-    // side panes
+  // side panes
     const transitionDuration = 0.4;
 
     // let's add an extra delay of 0.1 for even more robustness
@@ -94,7 +63,7 @@ export class GristWebDriverUtils {
    * Toggles (opens or closes) the right or left panel and wait for the transition to complete. An optional
    * argument can specify the desired state.
    */
-  public async toggleSidePanel(which: 'right' | 'left', goal: 'open' | 'close' | 'toggle' = 'toggle') {
+  public async toggleSidePanel(which: 'right'|'left', goal: 'open'|'close'|'toggle' = 'toggle') {
     if ((goal === 'open' && await this.isSidePanelOpen(which)) ||
       (goal === 'close' && !await this.isSidePanelOpen(which))) {
       return;
@@ -112,14 +81,20 @@ export class GristWebDriverUtils {
    * Gets browser window dimensions.
    */
   public async getWindowDimensions(): Promise<WindowDimensions> {
-    const { width, height } = await this.driver.manage().window().getRect();
-    return { width, height };
+    const {width, height} = await this.driver.manage().window().getRect();
+    return {width, height};
   }
 
+  /**
+   * Sets browser window dimensions.
+   */
+  public setWindowDimensions(width: number, height: number) {
+    return this.driver.manage().window().setRect({ width, height });
+  }
 
   // Add a new widget to the current page using the 'Add New' menu.
   public async addNewSection(
-    typeRe: RegExp | SectionTypes, tableRe: RegExp | string, options?: PageWidgetPickerOptions
+    typeRe: RegExp|SectionTypes, tableRe: RegExp|string, options?: PageWidgetPickerOptions
   ) {
     // Click the 'Add widget to page' entry in the 'Add New' menu
     await this.driver.findWait('.test-dp-add-new', 2000).doClick();
@@ -132,22 +107,21 @@ export class GristWebDriverUtils {
   // Select type and table that matches respectively typeRe and tableRe and save. The widget picker
   // must be already opened when calling this function.
   public async selectWidget(
-    typeRe: RegExp | string,
-    tableRe: RegExp | string = '',
+    typeRe: RegExp|string,
+    tableRe: RegExp|string = '',
     options: PageWidgetPickerOptions = {}
   ) {
+    const {customWidget, dismissTips, dontAdd, selectBy, summarize, tableName} = options;
     const driver = this.driver;
-    if (options.dismissTips) { await this.dismissBehavioralPrompts(); }
+    if (dismissTips) { await this.dismissBehavioralPrompts(); }
 
     // select right type
-    await driver.findContent('.test-wselect-type', typeRe).doClick();
+    await driver.findContentWait('.test-wselect-type', typeRe, 500).doClick();
 
-    if (options.dismissTips) { await this.dismissBehavioralPrompts(); }
+    if (dismissTips) { await this.dismissBehavioralPrompts(); }
 
     if (tableRe) {
-      const tableEl = driver.findContentWait('.test-wselect-table', tableRe, 2000);
-
-      if (options.dismissTips) { await this.dismissBehavioralPrompts(); }
+      const tableEl = driver.findContentWait('.test-wselect-table', tableRe, 100);
 
       // unselect all selected columns
       for (const col of (await driver.findAll('.test-wselect-column[class*=-selected]'))) {
@@ -157,34 +131,32 @@ export class GristWebDriverUtils {
       // let's select table
       await tableEl.click();
 
-      if (options.dismissTips) { await this.dismissBehavioralPrompts(); }
+      if (dismissTips) { await this.dismissBehavioralPrompts(); }
 
       const pivotEl = tableEl.find('.test-wselect-pivot');
       if (await pivotEl.isPresent()) {
-        await this.toggleSelectable(pivotEl, Boolean(options.summarize));
+        await this.toggleSelectable(pivotEl, Boolean(summarize));
       }
 
-      if (options.summarize) {
+      if (summarize) {
         for (const columnEl of await driver.findAll('.test-wselect-column')) {
           const label = await columnEl.getText();
           // TODO: Matching cols with regexp calls for trouble and adds no value. I think function should be
           // rewritten using string matching only.
-          const goal = Boolean(options.summarize.find(r => label.match(r)));
+          const goal = Boolean(summarize.find(r => label.match(r)));
           await this.toggleSelectable(columnEl, goal);
         }
       }
 
-      if (options.selectBy) {
+      if (selectBy) {
         // select link
-        await driver.find('.test-wselect-selectby').doClick();
-        await driver.findContent('.test-wselect-selectby option', options.selectBy).doClick();
+        await driver.findWait('.test-wselect-selectby', 100).doClick();
+        await driver.findContentWait('.test-wselect-selectby option', selectBy, 100).doClick();
       }
     }
 
 
-    if (options.dontAdd) {
-      return;
-    }
+    if (dontAdd) { return; }
 
     // add the widget
     await driver.find('.test-wselect-addBtn').doClick();
@@ -193,12 +165,18 @@ export class GristWebDriverUtils {
     const prompts = await driver.findAll(".test-modal-prompt");
     const prompt = prompts[0];
     if (prompt) {
-      if (options.tableName) {
+      if (tableName) {
         await prompt.doClear();
         await prompt.click();
-        await driver.sendKeys(options.tableName);
+        await driver.sendKeys(tableName);
       }
       await driver.find(".test-modal-confirm").click();
+    }
+
+    if (customWidget) {
+      await this.waitForServer();
+      await driver.findContent('.test-custom-widget-gallery-widget-name', customWidget).click();
+      await driver.find('.test-custom-widget-gallery-save').click();
     }
 
     await this.waitForServer();
@@ -249,29 +227,6 @@ export class GristWebDriverUtils {
     }
   }
 
-  public async openAccountMenu() {
-    const menu = await this.driver.findWait('.test-dm-account', 1000)
-    await menu.click();
-    // Since the AccountWidget loads orgs and the user data asynchronously, the menu
-    // can expand itself causing the click to land on a wrong button.
-    await this.waitForServer();
-    await this.driver.findWait('.test-dm-account-settings', 1000);
-    await this.driver.sleep(250);  // There's still some jitter (scroll-bar? other user accounts?)
-  }
-
-  public async openProfileSettingsPage(): Promise<ProfileSettingsPage> {
-    await this.openAccountMenu();
-    await this.driver.find('.grist-floating-menu .test-dm-account-settings').click();
-    //close alert if it is shown
-    if (await this.isAlertShown()) {
-      await this.acceptAlert();
-    }
-    await this.driver.findWait('.test-account-page-login-method', 5000);
-    await this.waitForServer();
-    return new ProfileSettingsPage(this);
-  }
-
-
   /**
    * Refresh browser and dismiss alert that is shown (for refreshing during edits).
    */
@@ -315,71 +270,155 @@ export class GristWebDriverUtils {
     await this.waitForDocToLoad();
   }
 
+  /**
+   * Sends UserActions using client api from the browser.
+   */
+  public async sendActions(actions: (DocAction | UserAction)[], optTimeout: number = 2000) {
+    await this.driver.manage().setTimeouts({
+      script: optTimeout, /* milliseconds */
+    });
+
+    // Make quick test that we have a list of actions not just a single action, by checking
+    // if the first element is an array.
+    if (actions.length && !Array.isArray(actions[0])) {
+      throw new Error('actions argument should be a list of actions, not a single action');
+    }
+
+    const result = await this.driver.executeAsyncScript(`
+    const done = arguments[arguments.length - 1];
+    const prom = gristDocPageModel.gristDoc.get().docModel.docData.sendActions(${JSON.stringify(actions)});
+    prom.then(() => done(null));
+    prom.catch((err) => done(String(err?.message || err)));
+  `);
+    if (result) {
+      throw new Error(result as string);
+    }
+    await this.waitForServer();
+  }
+
+  /**
+   * Runs a Grist command in the browser window.
+   */
+  public async sendCommand(name: CommandName, argument: any = null) {
+    await this.driver.executeAsyncScript((name: any, argument: any, done: any) => {
+      const result = (window as any).gristApp.allCommands[name].run(argument);
+      if (result?.finally) {
+        result.finally(done);
+      } else {
+        done();
+      }
+    }, name, argument);
+    await this.waitForServer();
+  }
+
+  public async openAccountMenu() {
+    await this.driver.findWait('.test-dm-account', 2000).click();
+    // Since the AccountWidget loads orgs and the user data asynchronously, the menu
+    // can expand itself causing the click to land on a wrong button.
+    await this.waitForServer();
+    await this.driver.findWait('.test-site-switcher-org', 2000);
+    await this.driver.sleep(250);  // There's still some jitter (scroll-bar? other user accounts?)
+  }
+
+  public async openProfileSettingsPage(): Promise<ProfileSettingsPage> {
+    await this.openAccountMenu();
+    await this.driver.find('.grist-floating-menu .test-dm-account-settings').click();
+    //close alert if it is shown
+    if (await this.isAlertShown()) {
+      await this.acceptAlert();
+    }
+    await this.driver.findWait('.test-account-page-login-method', 5000);
+    await this.waitForServer();
+    return new ProfileSettingsPage(this);
+  }
 
   /**
    * Click the Undo button and wait for server. If optCount is given, click Undo that many times.
    */
   public async undo(optCount: number = 1, optTimeout?: number) {
+    await this.waitForServer(optTimeout);
     for (let i = 0; i < optCount; ++i) {
       await this.driver.find('.test-undo').doClick();
+      await this.waitForServer(optTimeout);
     }
-    await this.waitForServer(optTimeout);
   }
 
+  /**
+   * Changes browser window dimensions for the duration of a test suite.
+   */
+  public resizeWindowForSuite(width: number, height: number) {
+    let oldDimensions: WindowDimensions;
+    before(async () => {
+      oldDimensions = await this.getWindowDimensions();
+      await this.setWindowDimensions(width, height);
+    });
+    after(async () => {
+      if (noCleanup) { return; }
+      await this.setWindowDimensions(oldDimensions.width, oldDimensions.height);
+    });
+  }
 
   /**
    * Changes browser window dimensions to FullHd for a test suite.
    */
   public bigScreen() {
-    let oldDimensions: WindowDimensions;
-    before(async () => {
-      oldDimensions = await this.driver.manage().window().getRect();
-      await this.driver.manage().window().setRect({ width: 1920, height: 1080 });
-    });
-    after(async () => {
-      await this.driver.manage().window().setRect(oldDimensions);
-    });
-  }
-
-  public async focusOnCell(columnName: string, row: number) {
-    const cell = await this.getCell({ col: columnName, rowNum: row });
-    await cell.click();
-  }
-  public async fillCell(columnName: string, row: number, value: string) {
-    await this.focusOnCell(columnName, row);
-    await this.driver.sendKeys(value)
-    await this.driver.sendKeys(Key.ENTER);
-  }
-
-  public async addColumn(table: string, name: string) {
-    // focus on table
-    await this.selectSectionByTitle(table);
-    // add new column using a shortcut
-    await this.driver.actions().keyDown(Key.ALT).sendKeys('=').keyUp(Key.ALT).perform();
-    // wait for rename panel to show up 
-    await this.driver.findWait('.test-column-title-popup', 1000);
-    // rename and accept
-    await this.driver.sendKeys(name);
-    await this.driver.sendKeys(Key.ENTER);
-    await this.waitForServer();
+    this.resizeWindowForSuite(1920, 1080);
   }
 
   /**
-   * Click into a section without disrupting cursor positions.
+   * Shrinks browser window dimensions to trigger mobile mode for a test suite.
    */
-  public async selectSectionByTitle(title: string|RegExp) {
-    try {
-      if (typeof title === 'string') {
-        title = new RegExp("^" + escapeRegExp(title) + "$", 'i');
-      }
-      // .test-viewsection is a special 1px width element added for tests only.
-      await this.driver.findContent(`.test-viewsection-title`, title).find(".test-viewsection-blank").click();
-    } catch (e) {
-      // We might be in mobile view.
-      await this.driver.findContent(`.test-viewsection-title`, title).findClosest(".view_leaf").click();
-    }
+  public narrowScreen() {
+    this.resizeWindowForSuite(400, 750);
   }
 
+  /**
+ * Returns visible cells of the GridView from a single column and one or more rows. Options may be
+ * given as arguments directly, or as an object.
+ * - col: column name, or 0-based column index
+ * - rowNums: array of 1-based row numbers, as visible in the row headers on the left of the grid.
+ * - section: optional name of the section to use; will use active section if omitted.
+ *
+ * If given by an object, then an array of columns is also supported. In this case, the return
+ * value is still a single array, listing all values from the first row, then the second, etc.
+ *
+ * Returns cell text by default. Mapper may be `identity` to return the cell objects.
+ */
+  public async getVisibleGridCells(col: number | string, rows: number[], section?: string): Promise<string[]>;
+  public async getVisibleGridCells<T = string>(options: IColSelect<T> | IColsSelect<T>): Promise<T[]>;
+  public async getVisibleGridCells<T>(
+    colOrOptions: number | string | IColSelect<T> | IColsSelect<T>, _rowNums?: number[], _section?: string
+  ): Promise<T[]> {
+
+    if (typeof colOrOptions === 'object' && 'cols' in colOrOptions) {
+      const { rowNums, section, mapper } = colOrOptions;    // tslint:disable-line:no-shadowed-variable
+      const columns = await Promise.all(colOrOptions.cols.map((oneCol) =>
+        this.getVisibleGridCells({ col: oneCol, rowNums, section, mapper })));
+      // This zips column-wise data into a flat row-wise array of values.
+      return ([] as T[]).concat(...rowNums.map((_r, i) => columns.map((c) => c[i])));
+    }
+
+    const { col, rowNums, section, mapper = el => el.getText() }: IColSelect<any> = (
+      typeof colOrOptions === 'object' ? colOrOptions :
+        { col: colOrOptions, rowNums: _rowNums!, section: _section }
+    );
+
+    if (rowNums.includes(0)) {
+      // Row-numbers should be what the users sees: 0 is a mistake, so fail with a helpful message.
+      throw new Error('rowNum must not be 0');
+    }
+
+    const sectionElem = section ? await this.getSection(section) : await this.driver.findWait('.active_section', 4000);
+    const colIndex = (typeof col === 'number' ? col :
+      await sectionElem.findContent('.column_name', this.exactMatch(col)).index());
+
+    const visibleRowNums: number[] = await sectionElem.findAll('.gridview_data_row_num',
+      async (el) => parseInt(await el.getText(), 10));
+
+    const selector = `.gridview_data_scroll .record:not(.column_names) .field:nth-child(${colIndex + 1})`;
+    const fields = mapper ? await sectionElem.findAll(selector, mapper) : await sectionElem.findAll(selector);
+    return rowNums.map((n) => fields[visibleRowNums.indexOf(n)]);
+  }
 
   /**
    * Returns a visible GridView cell. Options may be given as arguments directly, or as an object.
@@ -398,73 +437,40 @@ export class GristWebDriverUtils {
   }
 
   /**
-   * Returns visible cells of the GridView from a single column and one or more rows. Options may be
-   * given as arguments directly, or as an object.
-   * - col: column name, or 0-based column index
-   * - rowNums: array of 1-based row numbers, as visible in the row headers on the left of the grid.
-   * - section: optional name of the section to use; will use active section if omitted.
-   *
-   * If given by an object, then an array of columns is also supported. In this case, the return
-   * value is still a single array, listing all values from the first row, then the second, etc.
-   *
-   * Returns cell text by default. Mapper may be `identity` to return the cell objects.
+   * Returns a WebElementPromise for the .viewsection_content element for the section which contains
+   * the given text (case insensitive) content.
    */
-  public async getVisibleGridCells(col: number | string, rows: number[], section?: string): Promise<string[]>;
-  public async getVisibleGridCells<T = string>(options: IColSelect<T> | IColsSelect<T>): Promise<T[]>;
-  public async getVisibleGridCells<T>(
-    colOrOptions: number | string | IColSelect<T> | IColsSelect<T>, _rowNums?: number[], _section?: string
-  ): Promise<T[]> {
-
-    if (typeof colOrOptions === 'object' && 'cols' in colOrOptions) {
-      const { rowNums, section, mapper } = colOrOptions;    // tslint:disable-line:no-shadowed-variable
-      const columns = await Promise.all(colOrOptions.cols.map((oneCol) =>
-        this.getVisibleGridCells({ col: oneCol, rowNums, section, mapper })));
-      // This zips column-wise data into a flat row-wise array of values.
-      return ([] as T[]).concat(...rowNums.map((r, i) => columns.map((c) => c[i])));
-    }
-
-    const { col, rowNums, section, mapper = el => el.getText() }: IColSelect<any> = (
-      typeof colOrOptions === 'object' ? colOrOptions :
-        { col: colOrOptions, rowNums: _rowNums!, section: _section }
-    );
-
-    if (rowNums.includes(0)) {
-      // Row-numbers should be what the users sees: 0 is a mistake, so fail with a helpful message.
-      throw new Error('rowNum must not be 0');
-    }
-
-    const sectionElem = section ? await this.getSection(section) : await this.driver.findWait('.active_section', 4000);
-    const colIndex = (typeof col === 'number' ? col :
-      await sectionElem.findContent('.column_name', exactMatch(col)).index());
-
-    const visibleRowNums: number[] = await sectionElem.findAll('.gridview_data_row_num',
-      async (el) => parseInt(await el.getText(), 10));
-
-    const selector = `.gridview_data_scroll .record:not(.column_names) .field:nth-child(${colIndex + 1})`;
-    const fields = mapper ? await sectionElem.findAll(selector, mapper) : await sectionElem.findAll(selector);
-    return rowNums.map((n) => fields[visibleRowNums.indexOf(n)]);
-  }
-
   public getSection(sectionOrTitle: string | WebElement): WebElement | WebElementPromise {
     if (typeof sectionOrTitle !== 'string') { return sectionOrTitle; }
     return this.driver.findContent(`.test-viewsection-title`, new RegExp("^" + escapeRegExp(sectionOrTitle) + "$", 'i'))
       .findClosest('.viewsection_content');
   }
-}
 
-class ProfileSettingsPage {
-  private driver: WebDriver;
-  private gu: GristWebDriverUtils;
-
-  constructor(gu: GristWebDriverUtils) {
-    this.gu = gu;
-    this.driver = gu.driver;
+  /**
+   * Helper for exact string matches using interfaces that expect a RegExp. E.g.
+   *    driver.findContent('.selector', exactMatch("Foo"))
+   *
+   * TODO It would be nice if mocha-webdriver allowed exact string match in findContent() (it now
+   * supports a substring match, but we still need a helper for an exact match).
+   */
+  public exactMatch(value: string, flags?: string): RegExp {
+    return new RegExp(`^${escapeRegExp(value)}$`, flags);
   }
 
-  public async setLanguage(language: string) {
-    await this.driver.findWait('.test-account-page-language .test-select-open', 100).click();
-    await this.driver.findContentWait('.test-select-menu li', language, 100).click();
-    await this.gu.waitForServer();
+  /**
+   * Click into a section without disrupting cursor positions.
+   */
+  public async selectSectionByTitle(title: string | RegExp) {
+    try {
+      if (typeof title === 'string') {
+        title = new RegExp("^" + escapeRegExp(title) + "$", 'i');
+      }
+      // .test-viewsection is a special 1px width element added for tests only.
+      await this.driver.findContent(`.test-viewsection-title`, title).find(".test-viewsection-blank").click();
+    } catch (e) {
+      // We might be in mobile view.
+      await this.driver.findContent(`.test-viewsection-title`, title).findClosest(".view_leaf").click();
+    }
   }
 }
 
@@ -476,35 +482,49 @@ export interface WindowDimensions {
 export interface PageWidgetPickerOptions {
   tableName?: string;
   /** Optional pattern of SELECT BY option to pick. */
-  selectBy?: RegExp | string;
+  selectBy?: RegExp|string;
   /** Optional list of patterns to match Group By columns. */
-  summarize?: (RegExp | string)[];
+  summarize?: (RegExp|string)[];
   /** If true, configure the widget selection without actually adding to the page. */
   dontAdd?: boolean;
   /** If true, dismiss any tooltips that are shown. */
   dismissTips?: boolean;
+  /** Optional pattern of custom widget name to select in the gallery. */
+  customWidget?: RegExp|string;
+}
+
+export class ProfileSettingsPage {
+  private _driver: WebDriver;
+  private _gu: GristWebDriverUtils;
+
+  constructor(gu: GristWebDriverUtils) {
+    this._gu = gu;
+    this._driver = gu.driver;
+  }
+
+  public async setLanguage(language: string) {
+    await this._driver.findWait('.test-account-page-language .test-select-open', 100).click();
+    await this._driver.findContentWait('.test-select-menu li', language, 100).click();
+    await this._gu.waitForServer();
+  }
 }
 
 export interface IColsSelect<T = WebElement> {
-  cols: Array<number | string>;
+  cols: Array<number|string>;
   rowNums: number[];
-  section?: string | WebElement;
+  section?: string|WebElement;
   mapper?: (e: WebElement) => Promise<T>;
 }
 
 export interface IColSelect<T = WebElement> {
-  col: number | string;
+  col: number|string;
   rowNums: number[];
-  section?: string | WebElement;
+  section?: string|WebElement;
   mapper?: (e: WebElement) => Promise<T>;
 }
 
 export interface ICellSelect {
-  col: number | string;
+  col: number|string;
   rowNum: number;
-  section?: string | WebElement;
-}
-
-export function exactMatch(value: string, flags?: string): RegExp {
-  return new RegExp(`^${escapeRegExp(value)}$`, flags);
+  section?: string|WebElement;
 }

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -4,4 +4,9 @@
     "*",
     "**/*",
   ],
+  "compilerOptions": {
+    "paths": {
+      "app/*": ["test/app/*"]
+    }
+  }
 }

--- a/test/viewer.ts
+++ b/test/viewer.ts
@@ -32,7 +32,7 @@ describe('viewer', function () {
     }
     before(async function () {
       //add set of images to the table
-      await grist.sendActionsAndWaitForServer(
+      await grist.sendActions(
         [
           ['AddRecord', 'Data', RowData.NONE, { Image: "" }],
           ['AddRecord', 'Data', RowData.NONE_NEXT, { Image: "" }],
@@ -117,7 +117,7 @@ describe('viewer', function () {
 
     after(async function () {
       //remove row added in before block
-      await grist.sendActionsAndWaitForServer([
+      await grist.sendActions([
         ['RemoveRecord', 'Data', 6],
         ['RemoveRecord', 'Data', 5],
         ['RemoveRecord', 'Data', 4],
@@ -171,7 +171,7 @@ describe('viewer', function () {
 
     after(async function () {
       //remove setted cell
-      await grist.sendActionsAndWaitForServer([
+      await grist.sendActions([
         ['RemoveRecord', 'Data', 1],
       ], 1000);
     });
@@ -179,7 +179,7 @@ describe('viewer', function () {
   describe('navigation', function () {
     before(async function () {
       //remove all cells from image table 
-      await grist.sendActionsAndWaitForServer([['RemoveRecord', 'Data', 1]], 1000);
+      await grist.sendActions([['RemoveRecord', 'Data', 1]], 1000);
     });
     describe('no image', function () {
       it('should have navigation buttons hidden', async function () {


### PR DESCRIPTION
As the header of that file says, it should have never been independently changed. Lots of changes happened to it regardless since the file was copied.

As a first step to fixing the tests, this restores the original copy from grist-core and moves all of the additions to a supplemental subclass.