### PR TITLE
Move from unkpg.com to cdn.jsdelivr.net

### DIFF
--- a/calendar/index.html
+++ b/calendar/index.html
@@ -69,7 +69,7 @@
 </script>
 <script src="https://uicdn.toast.com/tui.date-picker/latest/tui-date-picker.js"></script>
 <script src="https://uicdn.toast.com/calendar/latest/toastui-calendar.min.js"></script>
-<script src="https://unpkg.com/i18next@23.5.1/dist/umd/i18next.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/i18next@23.5.1/i18next.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/i18next-http-backend@1.3.1/i18nextHttpBackend.min.js"></script>
 
 <script src="page.js"></script>

--- a/calendar/package.json
+++ b/calendar/package.json
@@ -12,7 +12,7 @@
       "accessLevel": "full",
       "renderAfterReady": true,
       "archive": {
-        "domains": ["uicdn.toast.com", "maxcdn.bootstrapcdn.com", "unpkg.com", "cdn.jsdelivr.net"],
+        "domains": ["uicdn.toast.com", "maxcdn.bootstrapcdn.com", "cdn.jsdelivr.net"],
         "entrypoints": [
           "https://gristlabs.github.io/grist-widget/calendar/i18n/"
         ]

--- a/map/index.html
+++ b/map/index.html
@@ -1,15 +1,15 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css" />
-    <script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet-src.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.6.0/dist/leaflet.css" />
+    <script src="https://cdn.jsdelivr.net/npm/leaflet@1.6.0/dist/leaflet-src.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="screen.css" />
-    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
-    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
-    <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
+    <script src="https://cdn.jsdelivr.net/npm/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
     <!-- next line is optional - only if geocoding is desired -->
-    <script src="https://unpkg.com/leaflet-control-geocoder/dist/Control.Geocoder.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/leaflet-control-geocoder@3.1.0/dist/Control.Geocoder.js"></script>
     <script src="https://docs.getgrist.com/grist-plugin-api.js"></script>
     <script src="page.js"></script>
   </head>

--- a/markdown/index.html
+++ b/markdown/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <title>A cheap and cheerful Markdown viewer/editor</title>
     <script src="https://docs.getgrist.com/grist-plugin-api.js"></script>
-    <link rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css">
-    <script src="https://unpkg.com/easymde/dist/easymde.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/grainjs@1.0.2/dist/grain-full.min.js"></script>
     <script src="index.js"></script>
     <style>

--- a/notepad/index.html
+++ b/notepad/index.html
@@ -9,7 +9,7 @@
   <link href="https://cdn.jsdelivr.net/npm/quill@2.0.2/dist/quill.bubble.css" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/quill@2.0.2/dist/quill.js"></script>
   <link href="index.css" rel="stylesheet">
-  <script src="https://unpkg.com/rxjs@%5E7/dist/bundles/rxjs.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/rxjs@7.8.2/dist/bundles/rxjs.umd.min.js"></script>
   <script src="image-resize.min.js"></script>
 </head>
 

--- a/stock-monitor/index.html
+++ b/stock-monitor/index.html
@@ -2,7 +2,7 @@
 
 <head>
   <script src="https://docs.getgrist.com/grist-plugin-api.js"></script>
-  <script src="https://unpkg.com/vue@3"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vue@3.5.13/dist/vue.global.js"></script> 
   <style>
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;


### PR DESCRIPTION
Due to the recent somewhat common unavailability of unpkg.com ( https://github.com/unpkg/unpkg/issues/443 ) I have implemented a move of all the references from unpkg.com to cdn.jsdelivr.net . cdn.jsdeli.net has already been used for most of the CDN calls before, this just cleans things up and moves everything to one single provider. The files linked are identical.