### PR TITLE
Save and restore inclusions and exclusions to widget options

### DIFF
--- a/pivottable/index.js
+++ b/pivottable/index.js
@@ -28,7 +28,9 @@ const aggregators = {
 };
 
 grist.onRecords(async rec => {
-  const { rows, cols, vals, aggregatorName, rendererName } = await grist.getOption('settings') ?? {};
+  const {
+    rows, cols, vals, aggregatorName, rendererName, inclusions, exclusions
+  } = await grist.getOption('settings') ?? {};
   let initialRender = true;
   $('#table').pivotUI(
     rec,
@@ -41,11 +43,17 @@ grist.onRecords(async rec => {
           initialRender = false;
           return;
         }
-        const { rows, cols, vals, aggregatorName, rendererName } = config;
-        grist.setOption('settings', { rows, cols, vals, aggregatorName, rendererName });
+        const {
+          rows, cols, vals, aggregatorName, rendererName, inclusions, exclusions
+        } = config;
+        grist.setOption('settings', {
+          rows, cols, vals, aggregatorName, rendererName, inclusions, exclusions
+        });
       },
       aggregatorName,
       rendererName,
+      inclusions,
+      exclusions,
       aggregators: $.extend($.pivotUtilities.aggregators, aggregators),
       renderers: $.extend(
         $.pivotUtilities.renderers,


### PR DESCRIPTION
If you select a subset of values to include in the lists rows and columns (see screenshot), these changes are not saved to the widget options and are reset when the widget is loaded again. This PR fixes that, so that the row/column inclusions/exclusions are saved and restored.

![Copie d'écran_20250502_165139](https://github.com/user-attachments/assets/9f824dd7-b1c2-4d68-83b1-f918f4e26d1d)
