### PR TITLE
Fix <style> tags in Markdown widget.

### DIFF
--- a/markdown/index.html
+++ b/markdown/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
     <script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/grainjs@1.0.2/dist/grain-full.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.2.3/dist/purify.min.js"></script>
     <script src="index.js"></script>
     <style>
       :root {

--- a/markdown/index.js
+++ b/markdown/index.js
@@ -172,7 +172,7 @@ ready(() => {
         toolbar: editable ? toolbar : false,
         renderingConfig: {
           sanitizerFunction: function(renderedHTML) {
-            return DOMPurify.sanitize(renderedHTML);
+            return DOMPurify.sanitize(renderedHTML, {FORCE_BODY: true});
           },
         },
       });


### PR DESCRIPTION
- The issue was that DOMPurify default has the poor legacy default of `{WHOLE_DOCUMENT: false, FORCE_BODY: false}`, whose effect is to hoist the <style> tag at the beginning of content into document \<head> and then discard this \<head>. The effect is that the first <style> element is lost. It's not even the result of sanitization.

  Setting `FORCE_BODY: true` fixes it.

- Also upgrade DOMPurify CDN version to the same one used in the current version of Grist app itself.