### PR TITLE
Fix sanitization of renderhtml widget.

### DIFF
--- a/renderhtml/index.html
+++ b/renderhtml/index.html
@@ -33,7 +33,7 @@
         if (!content) {
           el.style.display = 'none';
         } else {
-          el.innerHTML = DOMPurify.sanitize(content, {ADD_TAGS, ADD_ATTR});
+          el.innerHTML = DOMPurify.sanitize(content, {ADD_TAGS, ADD_ATTR, FORCE_BODY: true});
           // If we are allowing scripts, let them execute, which doesn't
           // normally happen when adding script elements using innerHTML.
           if (ADD_TAGS?.includes("script")) {


### PR DESCRIPTION
Includes `FORCE_BODY: true` for dompurify. It moves certain <head>
elements like <style> into <body>, and also avoids dropping the <style> element when it's the first element.

This fixes issue https://github.com/gristlabs/grist-widget/issues/177