### PR TITLE
Sanitizing copyright in map widget

### DIFF
--- a/map/index.html
+++ b/map/index.html
@@ -11,6 +11,7 @@
     <!-- next line is optional - only if geocoding is desired -->
     <script src="https://cdn.jsdelivr.net/npm/leaflet-control-geocoder@3.1.0/dist/Control.Geocoder.js"></script>
     <script src="https://docs.getgrist.com/grist-plugin-api.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.2.3/dist/purify.min.js"></script>
     <script src="page.js"></script>
   </head>
   <body>

--- a/map/page.js
+++ b/map/page.js
@@ -217,7 +217,7 @@ function updateMap(data) {
   //    Old source was natgeo world map, but that only has data up to zoom 16
   //    (can't zoom in tighter than about 10 city blocks across)
   //
-  const tiles = L.tileLayer(mapSource, { attribution: mapCopyright });
+  const tiles = L.tileLayer(mapSource, { attribution: DOMPurify.sanitize(mapCopyright, {FORCE_BODY: true})});
 
   const error = document.querySelector('.error');
   if (error) { error.remove(); }


### PR DESCRIPTION
Sanitizing value passed to the attribution field in Leaflet library, that can show arbitrary [HTML](https://leafletjs.com/reference.html#control-attribution) value.