### PR TITLE
feat(calendar): detect first day of week from locale

### DIFF
--- a/calendar/page.js
+++ b/calendar/page.js
@@ -53,6 +53,21 @@ function getMonthName() {
   return calendarHandler.calendar.getDate().toDate().toLocaleString(getLanguage(), {month: 'long', year: 'numeric'})
 }
 
+function getFirstDayOfWeek() {
+  try {
+    const locale = new Intl.Locale(getLanguage());
+    // Chrome 99+ uses getWeekInfo(), Firefox 126+ and Safari 17+ use weekInfo property
+    const weekInfo = locale.getWeekInfo?.() ?? locale.weekInfo;
+    if (weekInfo?.firstDay !== undefined) {
+      // Intl: 1=Mon, ..., 7=Sun  →  TUI: 0=Sun, 1=Mon, ..., 6=Sat
+      return weekInfo.firstDay === 7 ? 0 : weekInfo.firstDay;
+    }
+  } catch (e) {
+    // Intl.Locale week info not supported by this browser
+  }
+  return 0; // fallback: Sunday
+}
+
 class CalendarHandler {
   //TODO: switch to new variables once they are published.
   _mainColor =  'var(--grist-theme-input-readonly-border)';
@@ -147,9 +162,11 @@ class CalendarHandler {
     return {
       week: {
         taskView: false,
+        startDayOfWeek: getFirstDayOfWeek(),
         dayNames: [t('Sun'), t('Mon'), t('Tue'), t('Wed'), t('Thu'), t('Fri'), t('Sat')],
       },
       month: {
+        startDayOfWeek: getFirstDayOfWeek(),
         dayNames: [t('Sun'), t('Mon'), t('Tue'), t('Wed'), t('Thu'), t('Fri'), t('Sat')],
       },
       usageStatistics: false,

--- a/calendar/page.js
+++ b/calendar/page.js
@@ -55,7 +55,7 @@ function getMonthName() {
 
 function getFirstDayOfWeek() {
   try {
-    const locale = new Intl.Locale(getLanguage());
+    const locale = new Intl.Locale(urlParams.get('culture') ?? navigator.language ?? getLanguage());
     // Chrome 99+ uses getWeekInfo(), Firefox 126+ and Safari 17+ use weekInfo property
     const weekInfo = locale.getWeekInfo?.() ?? locale.weekInfo;
     if (weekInfo?.firstDay !== undefined) {


### PR DESCRIPTION
## feat(calendar): detect first day of week from locale

### Problem

The Grist calendar widget always displayed weeks starting on **Sunday**,
regardless of the user's locale. In most European and many other locales,
weeks should start on **Monday**.

### Fix

Added a `getFirstDayOfWeek()` function that reads the first weekday from
the browser's `Intl.Locale` API:

- Reads locale from the Grist `culture` URL parameter first, then falls
  back to `navigator.language` and finally to the widget's active language
- Uses `locale.getWeekInfo()` (Chrome 99+) or `locale.weekInfo` (Firefox
  126+, Safari 17+) to retrieve the locale's first weekday
- Converts from Intl convention (1=Mon…7=Sun) to TUI Calendar convention
  (0=Sun, 1=Mon…6=Sat)
- Falls back to `0` (Sunday) if the API is not supported

`startDayOfWeek` is set on both `week` and `month` calendar options so all
views are consistent.

A follow-up commit (`fix: use Grist culture param for first day of week
detection`) ensures the Grist `culture` URL parameter is prioritised, so
the calendar respects the language/region configured in the Grist document
settings rather than the browser OS locale alone.

### Files changed

- `calendar/page.js` — `getFirstDayOfWeek()` function + `startDayOfWeek`
  in `week` and `month` options

### Testing

1. Open the widget with a French (`fr-FR`) Grist culture → weeks start on Monday
2. Open with `en-US` culture → weeks start on Sunday
3. Verify behaviour is the same in week view and month view
4. In a browser that does not support `Intl.Locale.getWeekInfo` → fallback
   to Sunday, no JS error