### PR TITLE
Wait for the test Grist server to start up cleanly

### DIFF
--- a/test/getGrist.ts
+++ b/test/getGrist.ts
@@ -65,6 +65,7 @@ export class GristTestServer {
     const cmd = `docker run -d --rm --name ${gristContainerName}` +
       ' --add-host=host.docker.internal:host-gateway' +
       ` -e PORT=${gristPort} -p ${gristPort}:${gristPort}` +
+      ` -e GRIST_IN_SERVICE=1` +
       ` -e GRIST_SINGLE_ORG=${serverSettings.site}` +
       ` -e GRIST_WIDGET_LIST_URL=http://host.docker.internal:${contentPort}/manifest.json` +
       ` ${gristImage}`;
@@ -144,7 +145,7 @@ export class GristUtils extends GristWebDriverUtils {
       }
       try {
         const url = this.url;
-        const resp = await fetch(url + '/status');
+        const resp = await fetch(url + '/status?ready=1');
         if (resp.status === 200) {
           break;
         }


### PR DESCRIPTION
Two small tweaks so our tests stop tripping over a fresh Grist server:

- We now set GRIST_IN_SERVICE=1 when we start the container, so Grist knows it's good to go and doesn't ask us to visit a setup page.
- We now wait on /status?ready=1, which only says "OK" once Grist is truly ready to take requests. The plain /status was answering "I'm alive!" a few seconds before it could actually do anything, and our uploads were sneaking in too early and getting turned away.