### PR TITLE
Add Widget Studio Pro to the gallery

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 	path = vibe-view
 	url = https://github.com/gristlabs/vibe-view-widget
   branch = main
+[submodule "widget-studio-pro"]
+	path = widget-studio-pro
+	url = https://github.com/isaytoo/grist-widget-studio-pro.git

--- a/external.jsonc
+++ b/external.jsonc
@@ -11,5 +11,11 @@
     // Flag is enforced to false to indicate that this is not a Grist Labs maintained widget.
     "isGristLabsMaintained": false
   },
-  "vibe-view": {}
+  "vibe-view": {},
+  "widget-studio-pro": {
+    "url": "https://gristlabs.github.io/grist-widget/widget-studio-pro/index.html",
+    "widgetId": "@isaytoo/grist-widget-studio-pro",
+    "isGristLabsMaintained": false,
+    "published": true
+  }
 }


### PR DESCRIPTION
## Summary

Adds **Widget Studio Pro** to the gallery via submodule + `external.jsonc` registration, following the same pattern as `form-builder`.

Widget Studio Pro is a full in-browser IDE for developing Grist custom widgets:

- Multi-file Monaco Editor (HTML / CSS / JS / JSON) with Grist plugin API IntelliSense
- Live preview with hot-reload
- Integrated API tester (Postman-like) with optional CORS proxy
- Console & Network debug panels
- Template library (Charts, Map, Kanban, Form, API consumer…)
- CDN package manager
- Export / Import as ZIP
- Dark / Light mode
- Grist table inspector
- Install mode: convert the studio output into a standalone widget inside the document
- FR / EN i18n

## Source

- Repository: https://github.com/isaytoo/grist-widget-studio-pro
- License: Apache-2.0
- Author: Said Hamadou ([@isaytoo](https://github.com/isaytoo))

## Changes

- `widget-studio-pro/` added as submodule pointing at https://github.com/isaytoo/grist-widget-studio-pro
- `external.jsonc` registers `widget-studio-pro` with `widgetId: @isaytoo/grist-widget-studio-pro`, `isGristLabsMaintained: false`, `published: true`
- Submodule's own `package.json` carries the full `grist` config consumed by `buildtools/publish.js`

## Test plan

- [ ] `yarn build` produces a `manifest.json` containing `@isaytoo/grist-widget-studio-pro`
- [ ] Widget loads from `https://gristlabs.github.io/grist-widget/widget-studio-pro/index.html`
- [ ] Editor, live preview, template library and i18n switch work in a Grist document