### PR TITLE
Moves all dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "commander": "11.1.0",
     "concurrently": "9.2.1",
     "connect-livereload": "0.6.1",
+    "http-server": "14.1.1",
+    "jsonc": "2.0.0",
     "livereload": "0.10.3",
     "lodash": "4.18.1",
     "lodash.escaperegexp": "4.1.2",
@@ -46,8 +48,6 @@
     "typescript": "5.1.3"
   },
   "dependencies": {
-    "http-server": "14.1.1",
-    "jsonc": "2.0.0"
   },
   "mocha": {
     "require": [


### PR DESCRIPTION
http-server and jsonc are only used in development scripts.

Move them to devDependencies so grist-widget has no dependencies when bundled.