### PR TITLE
Fix tests against latest Grist image

### DIFF
--- a/test/chart.ts
+++ b/test/chart.ts
@@ -4,7 +4,7 @@ import {getGrist} from 'test/getGrist';
 describe('chart', function () {
   this.timeout(10000);
   const grist = getGrist();
-  grist.bigScreen();
+  grist.bigScreen('big');
 
   it('can create a basic chart', async function () {
     // Open fixture doc

--- a/test/getGrist.ts
+++ b/test/getGrist.ts
@@ -48,6 +48,7 @@ const serverSettings = {
   gristImage: 'gristlabs/grist',
   gristPort: 9999,
   contentPort: 9998,
+  untrustedPort: 9997,
   site: 'grist-widget',
 };
 
@@ -61,13 +62,18 @@ export class GristTestServer {
 
   public async start() {
     await this.stop();
-    const {gristContainerName, gristImage, gristPort, contentPort} = serverSettings;
+    const {gristContainerName, gristImage, gristPort, contentPort, untrustedPort} = serverSettings;
     const cmd = `docker run -d --rm --name ${gristContainerName}` +
       ' --add-host=host.docker.internal:host-gateway' +
       ` -e PORT=${gristPort} -p ${gristPort}:${gristPort}` +
       ` -e GRIST_IN_SERVICE=1` +
       ` -e GRIST_SINGLE_ORG=${serverSettings.site}` +
       ` -e GRIST_WIDGET_LIST_URL=http://host.docker.internal:${contentPort}/manifest.json` +
+      // Pin the untrusted-port server (used for bundled custom widgets) to a
+      // known port and expose it, so the host browser can load bundled widget
+      // iframes. Grist's default is to pick a random port that's only
+      // reachable inside the container.
+      ` -e GRIST_UNTRUSTED_PORT=${untrustedPort} -p ${untrustedPort}:${untrustedPort}` +
       ` ${gristImage}`;
     try {
       execSync(cmd, {

--- a/test/gristWebDriverUtils.ts
+++ b/test/gristWebDriverUtils.ts
@@ -8,12 +8,13 @@
  * easily.
  */
 
-import escapeRegExp = require('lodash/escapeRegExp');
-import { CommandName } from 'app/client/components/commandList';
-import { DocAction, UserAction } from 'app/common/DocActions';
-import { WebDriver, WebElement, WebElementPromise } from 'mocha-webdriver';
+import { CommandName } from "app/client/components/commandList";
+import { DocAction, UserAction } from "app/common/DocActions";
 
-type SectionTypes = 'Table'|'Card'|'Card List'|'Chart'|'Custom'|'Form';
+import escapeRegExp from "lodash/escapeRegExp";
+import { WebDriver, WebElement, WebElementPromise } from "mocha-webdriver";
+
+type SectionTypes = "Table" | "Card" | "Card List" | "Chart" | "Custom" | "Form";
 
 // it is sometimes useful in debugging to turn off automatic cleanup of docs and workspaces.
 export const noCleanup = Boolean(process.env.NO_CLEANUP);
@@ -22,8 +23,8 @@ export class GristWebDriverUtils {
   public constructor(public driver: WebDriver) {
   }
 
-  public isSidePanelOpen(which: 'right'|'left'): Promise<boolean> {
-    return this.driver.find(`.test-${which}-panel`).matches('[class*=-open]');
+  public isSidePanelOpen(which: "right" | "left"): Promise<boolean> {
+    return this.driver.find(`.test-${which}-panel`).matches("[class*=-open]");
   }
 
   /**
@@ -36,53 +37,49 @@ export class GristWebDriverUtils {
    */
   public async waitForServer(optTimeout: number = 5000) {
     await this.driver.wait(() => this.driver.executeScript(
-      "return window.gristApp && (!window.gristApp.comm || !window.gristApp.comm.hasActiveRequests())"
-        + " && window.gristApp.testNumPendingApiRequests() === 0"
-      )
+      "return window.gristApp && (!window.gristApp.comm || !window.gristApp.comm.hasActiveRequests())" +
+      " && window.gristApp.testNumPendingApiRequests() === 0",
+    )
       // The catch is in case executeScript() fails. This is rare but happens occasionally when
       // browser is busy (e.g. sorting) and doesn't respond quickly enough. The timeout selenium
       // allows for a response is short (and I see no place to configure it); by catching, we'll
       // let the call fail until our intended timeout expires.
       .catch((e) => { console.log("Ignoring executeScript error", String(e)); }),
-      optTimeout,
-      "Timed out waiting for server requests to complete"
+    optTimeout,
+    "Timed out waiting for server requests to complete",
     );
   }
 
-  public async waitForSidePanel() {
-    // 0.4 is the duration of the transition setup in app/client/ui/PagePanels.ts for opening the
-  // side panes
-    const transitionDuration = 0.4;
-
-    // let's add an extra delay of 0.1 for even more robustness
-    const delta = 0.1;
-    await this.driver.sleep((transitionDuration + delta) * 1000);
+  public async waitForSidePanel(which: "left" | "right", state: "expanded" | "collapsed") {
+    // This part is fragile, makes tests flaky and should be replaced.
+    await this.driver.findWait(`.test-${which}-panel[data-fully-${state}]`, 5000);
   }
 
   /*
    * Toggles (opens or closes) the right or left panel and wait for the transition to complete. An optional
    * argument can specify the desired state.
    */
-  public async toggleSidePanel(which: 'right'|'left', goal: 'open'|'close'|'toggle' = 'toggle') {
-    if ((goal === 'open' && await this.isSidePanelOpen(which)) ||
-      (goal === 'close' && !await this.isSidePanelOpen(which))) {
+  public async toggleSidePanel(which: "right" | "left", goal: "open" | "close" | "toggle" = "toggle") {
+    const isOpen = await this.isSidePanelOpen(which);
+    if ((goal === "open" && isOpen) || (goal === "close" && !isOpen)) {
       return;
     }
 
     // Adds '-ns' when narrow screen
-    const suffix = (await this.getWindowDimensions()).width < 768 ? '-ns' : '';
+    const suffix = (await this.getWindowDimensions()).width < 768 ? "-ns" : "";
 
     // click the opener and wait for the duration of the transition
     await this.driver.find(`.test-${which}-opener${suffix}`).doClick();
-    await this.waitForSidePanel();
+    const newState = isOpen ? "collapsed" : "expanded";
+    await this.waitForSidePanel(which, newState);
   }
 
   /**
    * Gets browser window dimensions.
    */
   public async getWindowDimensions(): Promise<WindowDimensions> {
-    const {width, height} = await this.driver.manage().window().getRect();
-    return {width, height};
+    const { width, height } = await this.driver.manage().window().getRect();
+    return { width, height };
   }
 
   /**
@@ -94,11 +91,11 @@ export class GristWebDriverUtils {
 
   // Add a new widget to the current page using the 'Add New' menu.
   public async addNewSection(
-    typeRe: RegExp|SectionTypes, tableRe: RegExp|string, options?: PageWidgetPickerOptions
+    typeRe: RegExp | SectionTypes, tableRe: RegExp | string, options?: PageWidgetPickerOptions,
   ) {
     // Click the 'Add widget to page' entry in the 'Add New' menu
-    await this.driver.findWait('.test-dp-add-new', 2000).doClick();
-    await this.driver.findWait('.test-dp-add-widget-to-page', 500).doClick();
+    await this.driver.findWait(".test-dp-add-new", 2000).doClick();
+    await this.driver.findWait(".test-dp-add-widget-to-page", 500).doClick();
 
     // add widget
     await this.selectWidget(typeRe, tableRe, options);
@@ -107,24 +104,24 @@ export class GristWebDriverUtils {
   // Select type and table that matches respectively typeRe and tableRe and save. The widget picker
   // must be already opened when calling this function.
   public async selectWidget(
-    typeRe: RegExp|string,
-    tableRe: RegExp|string = '',
-    options: PageWidgetPickerOptions = {}
+    typeRe: RegExp | string,
+    tableRe: RegExp | string = "",
+    options: PageWidgetPickerOptions = {},
   ) {
-    const {customWidget, dismissTips, dontAdd, selectBy, summarize, tableName} = options;
+    const { customWidget, dismissTips, dontAdd, selectBy, summarize, tableName } = options;
     const driver = this.driver;
     if (dismissTips) { await this.dismissBehavioralPrompts(); }
 
     // select right type
-    await driver.findContentWait('.test-wselect-type', typeRe, 500).doClick();
+    await driver.findContentWait(".test-wselect-type", typeRe, 500).doClick();
 
     if (dismissTips) { await this.dismissBehavioralPrompts(); }
 
     if (tableRe) {
-      const tableEl = driver.findContentWait('.test-wselect-table', tableRe, 100);
+      const tableEl = driver.findContentWait(".test-wselect-table", tableRe, 100);
 
       // unselect all selected columns
-      for (const col of (await driver.findAll('.test-wselect-column[class*=-selected]'))) {
+      for (const col of (await driver.findAll(".test-wselect-column[class*=-selected]"))) {
         await col.click();
       }
 
@@ -133,13 +130,13 @@ export class GristWebDriverUtils {
 
       if (dismissTips) { await this.dismissBehavioralPrompts(); }
 
-      const pivotEl = tableEl.find('.test-wselect-pivot');
+      const pivotEl = tableEl.find(".test-wselect-pivot");
       if (await pivotEl.isPresent()) {
         await this.toggleSelectable(pivotEl, Boolean(summarize));
       }
 
       if (summarize) {
-        for (const columnEl of await driver.findAll('.test-wselect-column')) {
+        for (const columnEl of await driver.findAll(".test-wselect-column")) {
           const label = await columnEl.getText();
           // TODO: Matching cols with regexp calls for trouble and adds no value. I think function should be
           // rewritten using string matching only.
@@ -150,16 +147,15 @@ export class GristWebDriverUtils {
 
       if (selectBy) {
         // select link
-        await driver.findWait('.test-wselect-selectby', 100).doClick();
-        await driver.findContentWait('.test-wselect-selectby option', selectBy, 100).doClick();
+        await driver.findWait(".test-wselect-selectby", 100).doClick();
+        await driver.findContentWait(".test-wselect-selectby option", selectBy, 100).doClick();
       }
     }
-
 
     if (dontAdd) { return; }
 
     // add the widget
-    await driver.find('.test-wselect-addBtn').doClick();
+    await driver.find(".test-wselect-addBtn").doClick();
 
     // if we selected a new table, there will be a popup for a name
     const prompts = await driver.findAll(".test-modal-prompt");
@@ -175,8 +171,8 @@ export class GristWebDriverUtils {
 
     if (customWidget) {
       await this.waitForServer();
-      await driver.findContent('.test-custom-widget-gallery-widget-name', customWidget).click();
-      await driver.find('.test-custom-widget-gallery-save').click();
+      await driver.findContent(".test-custom-widget-gallery-widget-name", customWidget).click();
+      await driver.find(".test-custom-widget-gallery-save").click();
     }
 
     await this.waitForServer();
@@ -190,11 +186,11 @@ export class GristWebDriverUtils {
     const max = 10;
 
     // Keep dismissing prompts until there are no more, up to a maximum of 10 times.
-    while (i < max && await this.driver.find('.test-behavioral-prompt').isPresent()) {
+    while (i < max && await this.driver.find(".test-behavioral-prompt").isPresent()) {
       try {
-        await this.driver.findWait('.test-behavioral-prompt-dismiss', 100).click();
+        await this.driver.findWait(".test-behavioral-prompt-dismiss", 100).click();
       } catch (e) {
-        if (await this.driver.find('.test-behavioral-prompt').isPresent()) {
+        if (await this.driver.find(".test-behavioral-prompt").isPresent()) {
           throw e;
         }
         break;
@@ -209,7 +205,7 @@ export class GristWebDriverUtils {
    * -selected when selected.
    */
   public async toggleSelectable(elem: WebElement, goal: boolean) {
-    const isSelected = await elem.matches('[class*=-selected]');
+    const isSelected = await elem.matches("[class*=-selected]");
     if (goal !== isSelected) {
       await elem.click();
     }
@@ -237,16 +233,16 @@ export class GristWebDriverUtils {
   /**
    * Refresh browser and dismiss alert that is shown (for refreshing during edits).
    */
-  public async refreshDismiss() {
+  public async refreshDismiss({ ignore } = { ignore: false }) {
     await this.driver.navigate().refresh();
-    await this.acceptAlert();
+    await this.acceptAlert({ ignore });
     await this.waitForDocToLoad();
   }
 
   /**
    * Accepts an alert.
    */
-  public async acceptAlert({ignore} = {ignore: false}) {
+  public async acceptAlert({ ignore } = { ignore: false }) {
     try {
       await (await this.driver.switchTo().alert()).accept();
     } catch (e) {
@@ -276,12 +272,13 @@ export class GristWebDriverUtils {
    * ensure you are checking the new page and not the old.
    */
   public async waitForDocToLoad(timeoutMs: number = 10000): Promise<void> {
-    await this.driver.findWait('.viewsection_title', timeoutMs);
+    await this.driver.findWait(".viewsection_title", timeoutMs);
     await this.waitForServer();
   }
 
-  public async reloadDoc() {
+  public async reloadDoc(opt: { skipAlert?: boolean } = {}) {
     await this.driver.navigate().refresh();
+    if (opt.skipAlert && await this.isAlertShown()) { await this.acceptAlert(); }
     await this.waitForDocToLoad();
   }
 
@@ -296,7 +293,7 @@ export class GristWebDriverUtils {
     // Make quick test that we have a list of actions not just a single action, by checking
     // if the first element is an array.
     if (actions.length && !Array.isArray(actions[0])) {
-      throw new Error('actions argument should be a list of actions, not a single action');
+      throw new Error("actions argument should be a list of actions, not a single action");
     }
 
     const result = await this.driver.executeAsyncScript(`
@@ -327,22 +324,22 @@ export class GristWebDriverUtils {
   }
 
   public async openAccountMenu() {
-    await this.driver.findWait('.test-dm-account', 2000).click();
+    await this.driver.findWait(".test-dm-account", 2000).click();
     // Since the AccountWidget loads orgs and the user data asynchronously, the menu
     // can expand itself causing the click to land on a wrong button.
     await this.waitForServer();
-    await this.driver.findWait('.test-site-switcher-org', 2000);
+    await this.driver.findWait(".test-site-switcher-org", 2000);
     await this.driver.sleep(250);  // There's still some jitter (scroll-bar? other user accounts?)
   }
 
   public async openProfileSettingsPage(): Promise<ProfileSettingsPage> {
     await this.openAccountMenu();
-    await this.driver.find('.grist-floating-menu .test-dm-account-settings').click();
-    //close alert if it is shown
+    await this.driver.find(".grist-floating-menu .test-dm-account-settings").click();
+    // close alert if it is shown
     if (await this.isAlertShown()) {
       await this.acceptAlert();
     }
-    await this.driver.findWait('.test-account-page-login-method', 5000);
+    await this.driver.findWait(".test-account-page-login-method", 5000);
     await this.waitForServer();
     return new ProfileSettingsPage(this);
   }
@@ -353,7 +350,7 @@ export class GristWebDriverUtils {
   public async undo(optCount: number = 1, optTimeout?: number) {
     await this.waitForServer(optTimeout);
     for (let i = 0; i < optCount; ++i) {
-      await this.driver.find('.test-undo').doClick();
+      await this.driver.find(".test-undo").doClick();
       await this.waitForServer(optTimeout);
     }
   }
@@ -368,7 +365,6 @@ export class GristWebDriverUtils {
       await this.setWindowDimensions(width, height);
     });
     after(async () => {
-      if (noCleanup) { return; }
       await this.setWindowDimensions(oldDimensions.width, oldDimensions.height);
     });
   }
@@ -376,9 +372,9 @@ export class GristWebDriverUtils {
   /**
    * Changes browser window dimensions to FullHd for a test suite.
    */
-  public bigScreen(size: 'big'|'medium' = 'big') {
+  public bigScreen(size: "big" | "medium" = "medium") {
     // Note that the default (small) is 1024x640.
-    if (size === 'medium') {
+    if (size === "medium") {
       this.resizeWindowForSuite(1440, 900);
     } else {
       this.resizeWindowForSuite(1920, 1080);
@@ -407,37 +403,36 @@ export class GristWebDriverUtils {
   public async getVisibleGridCells(col: number | string, rows: number[], section?: string): Promise<string[]>;
   public async getVisibleGridCells<T = string>(options: IColSelect<T> | IColsSelect<T>): Promise<T[]>;
   public async getVisibleGridCells<T>(
-    colOrOptions: number | string | IColSelect<T> | IColsSelect<T>, _rowNums?: number[], _section?: string
+    colOrOptions: number | string | IColSelect<T> | IColsSelect<T>, _rowNums?: number[], _section?: string,
   ): Promise<T[]> {
-
-    if (typeof colOrOptions === 'object' && 'cols' in colOrOptions) {
-      const { rowNums, section, mapper } = colOrOptions;    // tslint:disable-line:no-shadowed-variable
-      const columns = await Promise.all(colOrOptions.cols.map((oneCol) =>
+    if (typeof colOrOptions === "object" && "cols" in colOrOptions) {
+      const { rowNums, section, mapper } = colOrOptions;
+      const columns = await Promise.all(colOrOptions.cols.map(oneCol =>
         this.getVisibleGridCells({ col: oneCol, rowNums, section, mapper })));
       // This zips column-wise data into a flat row-wise array of values.
-      return ([] as T[]).concat(...rowNums.map((_r, i) => columns.map((c) => c[i])));
+      return ([] as T[]).concat(...rowNums.map((_r, i) => columns.map(c => c[i])));
     }
 
     const { col, rowNums, section, mapper = el => el.getText() }: IColSelect<any> = (
-      typeof colOrOptions === 'object' ? colOrOptions :
+      typeof colOrOptions === "object" ? colOrOptions :
         { col: colOrOptions, rowNums: _rowNums!, section: _section }
     );
 
     if (rowNums.includes(0)) {
       // Row-numbers should be what the users sees: 0 is a mistake, so fail with a helpful message.
-      throw new Error('rowNum must not be 0');
+      throw new Error("rowNum must not be 0");
     }
 
-    const sectionElem = section ? await this.getSection(section) : await this.driver.findWait('.active_section', 4000);
-    const colIndex = (typeof col === 'number' ? col :
-      await sectionElem.findContent('.column_name', this.exactMatch(col)).index());
+    const sectionElem = section ? await this.getSection(section) : await this.driver.findWait(".active_section", 4000);
+    const colIndex = (typeof col === "number" ? col :
+      await sectionElem.findContentWait(".column_name", this.exactMatch(col), 1000).index());
 
-    const visibleRowNums: number[] = await sectionElem.findAll('.gridview_data_row_num',
-      async (el) => parseInt(await el.getText(), 10));
+    const visibleRowNums: number[] = await sectionElem.findAll(".gridview_data_row_num",
+      async el => parseInt(await el.getText(), 10));
 
     const selector = `.gridview_data_scroll .record:not(.column_names) .field:nth-child(${colIndex + 1})`;
     const fields = mapper ? await sectionElem.findAll(selector, mapper) : await sectionElem.findAll(selector);
-    return rowNums.map((n) => fields[visibleRowNums.indexOf(n)]);
+    return rowNums.map(n => fields[visibleRowNums.indexOf(n)]);
   }
 
   /**
@@ -450,10 +445,14 @@ export class GristWebDriverUtils {
   public getCell(options: ICellSelect): WebElementPromise;
   public getCell(colOrOptions: number | string | ICellSelect, rowNum?: number, section?: string): WebElementPromise {
     const mapper = async (el: WebElement) => el;
-    const options: IColSelect<WebElement> = (typeof colOrOptions === 'object' ?
+    const options: IColSelect<WebElement> = (typeof colOrOptions === "object" ?
       { col: colOrOptions.col, rowNums: [colOrOptions.rowNum], section: colOrOptions.section, mapper } :
       { col: colOrOptions, rowNums: [rowNum!], section, mapper });
-    return new WebElementPromise(this.driver, this.getVisibleGridCells(options).then((elems) => elems[0]));
+    return new WebElementPromise(this.driver, this.getVisibleGridCells(options).then(elems => elems[0]));
+  }
+
+  public waitCellFocus(cell: WebElement | WebElementPromise, timeout: number = 1000) {
+    return cell.findWait(".has_cursor", timeout);
   }
 
   /**
@@ -461,9 +460,9 @@ export class GristWebDriverUtils {
    * the given text (case insensitive) content.
    */
   public getSection(sectionOrTitle: string | WebElement): WebElement | WebElementPromise {
-    if (typeof sectionOrTitle !== 'string') { return sectionOrTitle; }
-    return this.driver.findContent(`.test-viewsection-title`, new RegExp("^" + escapeRegExp(sectionOrTitle) + "$", 'i'))
-      .findClosest('.viewsection_content');
+    if (typeof sectionOrTitle !== "string") { return sectionOrTitle; }
+    return this.driver.findContent(`.test-viewsection-title`, new RegExp("^" + escapeRegExp(sectionOrTitle) + "$", "i"))
+      .findClosest(".viewsection_content");
   }
 
   /**
@@ -482,8 +481,8 @@ export class GristWebDriverUtils {
    */
   public async selectSectionByTitle(title: string | RegExp) {
     try {
-      if (typeof title === 'string') {
-        title = new RegExp("^" + escapeRegExp(title) + "$", 'i');
+      if (typeof title === "string") {
+        title = new RegExp("^" + escapeRegExp(title) + "$", "i");
       }
       // .test-viewsection is a special 1px width element added for tests only.
       await this.driver.findContent(`.test-viewsection-title`, title).find(".test-viewsection-blank").click();
@@ -497,7 +496,7 @@ export class GristWebDriverUtils {
    * Click into a section without disrupting cursor positions.
    */
   public async selectSectionByIndex(index: number) {
-    const sections = await this.driver.findAll('.test-viewsection-title');
+    const sections = await this.driver.findAll(".test-viewsection-title");
     const section = sections.at(-1);
     if (section === undefined) {
       throw new Error(`No view section at index ${index}`);
@@ -520,15 +519,15 @@ export interface WindowDimensions {
 export interface PageWidgetPickerOptions {
   tableName?: string;
   /** Optional pattern of SELECT BY option to pick. */
-  selectBy?: RegExp|string;
+  selectBy?: RegExp | string;
   /** Optional list of patterns to match Group By columns. */
-  summarize?: (RegExp|string)[];
+  summarize?: (RegExp | string)[];
   /** If true, configure the widget selection without actually adding to the page. */
   dontAdd?: boolean;
   /** If true, dismiss any tooltips that are shown. */
   dismissTips?: boolean;
   /** Optional pattern of custom widget name to select in the gallery. */
-  customWidget?: RegExp|string;
+  customWidget?: RegExp | string;
 }
 
 export class ProfileSettingsPage {
@@ -541,28 +540,28 @@ export class ProfileSettingsPage {
   }
 
   public async setLanguage(language: string) {
-    await this._driver.findWait('.test-account-page-language .test-select-open', 100).click();
-    await this._driver.findContentWait('.test-select-menu li', language, 100).click();
+    await this._driver.findWait(".test-account-page-language .test-select-open", 100).click();
+    await this._driver.findContentWait(".test-select-menu li", language, 100).click();
     await this._gu.waitForServer();
   }
 }
 
 export interface IColsSelect<T = WebElement> {
-  cols: Array<number|string>;
+  cols: (number | string)[];
   rowNums: number[];
-  section?: string|WebElement;
+  section?: string | WebElement;
   mapper?: (e: WebElement) => Promise<T>;
 }
 
 export interface IColSelect<T = WebElement> {
-  col: number|string;
+  col: number | string;
   rowNums: number[];
-  section?: string|WebElement;
+  section?: string | WebElement;
   mapper?: (e: WebElement) => Promise<T>;
 }
 
 export interface ICellSelect {
-  col: number|string;
+  col: number | string;
   rowNum: number;
-  section?: string|WebElement;
+  section?: string | WebElement;
 }

--- a/test/jupyterlite.ts
+++ b/test/jupyterlite.ts
@@ -4,7 +4,7 @@ import {getGrist} from 'test/getGrist';
 describe('jupyterlite', function () {
   this.timeout(30000);
   const grist = getGrist();
-  grist.bigScreen();
+  grist.bigScreen('big');
 
   it('can create a basic notebook', async function () {
     // Open fixture doc


### PR DESCRIPTION
Two regressions from the moving gristlabs/grist:latest image:

1. Grist now serves bundled custom widgets on an "untrusted" port that defaults to a random in-container port the host browser can't reach. Pin GRIST_UNTRUSTED_PORT=9997 and publish it (test/getGrist.ts) so bundled widget iframes load.

2. gristWebDriverUtils.bigScreen() default dropped from 1920x1080 to 1440x900. The chart widget's plot collapses and JupyterLite's toolbar overlaps the cell at the smaller size, so chart.ts and jupyterlite.ts now pass 'big' explicitly.

test/gristWebDriverUtils.ts is a verbatim refresh from grist-core (see its own header) — no local edits, just a sync.