### PR TITLE
Show widget labels as text instead of HTML

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
+    # Backstop against a hung run.
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: [3.9]

--- a/flashcards/index.js
+++ b/flashcards/index.js
@@ -24,17 +24,30 @@ const ui = {
   progressText: null,
 };
 
-function getAnswerHTML(answer) {
+// A cell value as plain text (null/undefined become an empty string).
+function asText(value) {
+  return value == null ? '' : String(value);
+}
+
+// Show the answer as plain text via textContent. A list value
+// (e.g. a choice or reference list) becomes a simple bullet list.
+function renderAnswer(el, answer) {
+  el.textContent = '';
   if (!Array.isArray(answer)) {
-    return answer;
+    el.textContent = asText(answer);
+    return;
   }
-  return "<ul>\n" +
-    answer.map(v => `<li>${v}</li>`).join('\n') +
-    "</ul>";
+  const ul = document.createElement('ul');
+  for (const v of answer) {
+    const li = document.createElement('li');
+    li.textContent = asText(v);
+    ul.appendChild(li);
+  }
+  el.appendChild(ul);
 }
 
 function goNext(step) {
-  if (question.length === 0) { return; }
+  if (questions.length === 0) { return; }
   if (step === 'start') {
     at = 0;
   } else {
@@ -47,8 +60,8 @@ function goNext(step) {
   const qa = questions[at];
   // Store rowId, so we come back to the same card if possible, and restart if not.
   store.set('flashcards-rowid', qa.id);
-  ui.questionCard.innerHTML = qa.Question;
-  ui.answerCard.innerHTML = getAnswerHTML(qa.Answer);
+  ui.questionCard.textContent = asText(qa.Question);
+  renderAnswer(ui.answerCard, qa.Answer);
   setState('Q');
 }
 

--- a/map/page.js
+++ b/map/page.js
@@ -170,7 +170,10 @@ function scanOnNeed(mappings) {
 }
 
 function showProblem(txt) {
-  document.getElementById('map').innerHTML = '<div class="error">' + txt + '</div>';
+  const div = document.createElement('div');
+  div.className = 'error';
+  div.textContent = txt;
+  document.getElementById('map').replaceChildren(div);
 }
 
 // Little extra wrinkle to deal with showing differences.  Should be taken
@@ -282,7 +285,9 @@ function updateMap(data) {
       pane: (id == selectedRowId) ? "selectedMarker" : "otherMarkers",
     });
 
-    marker.bindPopup(name);
+    // Leaflet renders popup content as HTML, so tidy the label with
+    // DOMPurify before showing it.
+    marker.bindPopup(DOMPurify.sanitize(String(name ?? '')));
     markers.addLayer(marker);
 
     popups[id] = marker;

--- a/test/flashcards.ts
+++ b/test/flashcards.ts
@@ -30,4 +30,87 @@ describe('flashcards', function() {
       assert.equal(txt, 'ALBANY CITY SD');
     });
   });
+
+  it('shows the question and answer as plain text, not markup', async function() {
+    const docId = await grist.upload('test/fixtures/docs/Calendar.grist');
+    await grist.openDoc(docId);
+    await grist.dismissBehavioralPrompts();
+    await grist.toggleSidePanel('right', 'open');
+
+    // A label that happens to contain some HTML. We want it shown as text,
+    // character for character, rather than turned into real page elements.
+    const label = '<img src=x onerror="window.__ran = true">';
+    await grist.sendActions([
+      ['AddTable', 'Cards', [
+        {id: 'Question', type: 'Text'},
+        {id: 'Answer', type: 'Text'},
+      ]],
+      ['AddRecord', 'Cards', null, {Question: label, Answer: label}],
+    ]);
+
+    await grist.addNewSection(/Custom/, /Cards/, {dismissTips: true});
+    await grist.clickWidgetGallery();
+    await grist.selectCustomWidget(/Flash/);
+    await grist.setCustomWidgetAccess('full');
+    await grist.setCustomWidgetMapping('Question', /Question/);
+    await grist.setCustomWidgetMapping('Answer', /Answer/);
+
+    // The question shows up verbatim as text...
+    await grist.waitToPass(async () => {
+      assert.equal(await grist.getCustomWidgetBody('#question'), label);
+    });
+    // ...and it didn't turn into an actual element on the page.
+    assert.equal(
+      await grist.executeScriptInCustomWidget<number>(
+        () => document.querySelectorAll('#question img, #question script').length),
+      0);
+
+    // Same story once the answer is revealed.
+    await grist.inCustomWidget(async () => {
+      await grist.driver.find('#show').click();
+    });
+    await grist.waitToPass(async () => {
+      assert.equal(await grist.getCustomWidgetBody('#answer'), label);
+    });
+    assert.equal(
+      await grist.executeScriptInCustomWidget<number>(
+        () => document.querySelectorAll('#answer img, #answer script').length),
+      0);
+
+    // The inline handler never got a chance to run.
+    assert.notEqual(
+      await grist.executeScriptInCustomWidget(() => (window as any).__ran),
+      true);
+  });
+
+  it('handles a table with no records', async function() {
+    const docId = await grist.upload('test/fixtures/docs/Calendar.grist');
+    await grist.openDoc(docId);
+    await grist.dismissBehavioralPrompts();
+    await grist.toggleSidePanel('right', 'open');
+
+    // An empty deck must not break the widget (it used to run off the end of
+    // an empty list and throw).
+    await grist.sendActions([
+      ['AddTable', 'EmptyCards', [
+        {id: 'Question', type: 'Text'},
+        {id: 'Answer', type: 'Text'},
+      ]],
+    ]);
+
+    await grist.addNewSection(/Custom/, /EmptyCards/, {dismissTips: true});
+    await grist.clickWidgetGallery();
+    await grist.selectCustomWidget(/Flash/);
+    await grist.setCustomWidgetAccess('full');
+    await grist.setCustomWidgetMapping('Question', /Question/);
+    await grist.setCustomWidgetMapping('Answer', /Answer/);
+
+    // With no cards it stays on its initial prompt; the progress counter stays
+    // "?" rather than the "NaN of 0" the off-by-one produced just before it
+    // threw.
+    await grist.waitToPass(async () => {
+      assert.include(await grist.getCustomWidgetBody('#question'), 'Waiting for data...');
+      assert.equal(await grist.getCustomWidgetBody('#progress-text'), '?');
+    });
+  });
 });

--- a/test/getGrist.ts
+++ b/test/getGrist.ts
@@ -74,6 +74,10 @@ export class GristTestServer {
       // iframes. Grist's default is to pick a random port that's only
       // reachable inside the container.
       ` -e GRIST_UNTRUSTED_PORT=${untrustedPort} -p ${untrustedPort}:${untrustedPort}` +
+      // Hiding the help center also turns off in-product tips, whose tooltips
+      // otherwise pop up over the widget picker and swallow our clicks. See
+      // BehavioralPromptsManager.shouldShowPopup in grist-core.
+      ` -e GRIST_HIDE_UI_ELEMENTS=helpCenter` +
       ` ${gristImage}`;
     try {
       execSync(cmd, {
@@ -144,39 +148,30 @@ export class GristUtils extends GristWebDriverUtils {
   }
 
   public async wait() {
-    let ct = 0;
-    while (true) {
+    await this._waitForOk(this.url + '/status?ready=1', 'Grist');
+    await this._waitForOk(this.server.assetUrl, 'asset server');
+  }
+
+  // Poll a URL until it returns 200, bounded so a server that never starts
+  // fails fast instead of hanging the whole run.
+  private async _waitForOk(url: string, label: string) {
+    const intervalMs = 250;
+    const maxAttempts = 480; // ~120s
+    for (let ct = 0; ct < maxAttempts; ct++) {
       if (ct > 8) {
-        console.log("Waiting for Grist...");
+        console.log(`Waiting for ${label}...`);
       }
       try {
-        const url = this.url;
-        const resp = await fetch(url + '/status?ready=1');
+        const resp = await fetch(url);
         if (resp.status === 200) {
-          break;
+          return;
         }
       } catch (e) {
         // we expect fetch failures initially.
       }
-      await new Promise(resolve => setTimeout(resolve, 250));
-      ct++;
+      await new Promise(resolve => setTimeout(resolve, intervalMs));
     }
-    ct = 0;
-    while (true) {
-      if (ct > 8) {
-        console.log("Waiting for asset server...");
-      }
-      try {
-        const resp = await fetch(this.server.assetUrl);
-        if (resp.status === 200) {
-          break;
-        }
-      } catch (e) {
-        // we expect fetch failures initially.
-      }
-      await new Promise(resolve => setTimeout(resolve, 250));
-      ct++;
-    }
+    throw new Error(`Timed out waiting for ${label} to be ready at ${url}`);
   }
 
   public async upload(gristFileName: string): Promise<string> {

--- a/test/map.ts
+++ b/test/map.ts
@@ -1,0 +1,53 @@
+import { assert } from 'mocha-webdriver';
+import { getGrist } from "./getGrist";
+
+describe('map', function() {
+  this.timeout(30000);
+  const grist = getGrist();
+
+  it('shows marker labels as tidied-up text', async function() {
+    const docId = await grist.upload('test/fixtures/docs/Calendar.grist');
+    await grist.openDoc(docId);
+    await grist.dismissBehavioralPrompts();
+    await grist.toggleSidePanel('right', 'open');
+
+    // A label that happens to contain some HTML. Leaflet popups render their
+    // content as HTML, so we tidy it up first. Coordinates are Bourg-en-Bresse,
+    // away from 0,0 so the widget doesn't skip the point as a bad import.
+    const label = '<img src=x onerror="window.__ran = true">';
+    await grist.sendActions([
+      ['AddTable', 'Places', [
+        {id: 'Name', type: 'Text'},
+        {id: 'Latitude', type: 'Numeric'},
+        {id: 'Longitude', type: 'Numeric'},
+      ]],
+      ['AddRecord', 'Places', null, {Name: label, Latitude: 46.2, Longitude: 5.22}],
+    ]);
+
+    await grist.addNewSection(/Custom/, /Places/, {dismissTips: true});
+    await grist.clickWidgetGallery();
+    await grist.selectCustomWidget(/Map/);
+    await grist.setCustomWidgetAccess('full');
+    await grist.setCustomWidgetMapping('Name', /Name/);
+    await grist.setCustomWidgetMapping('Longitude', /Longitude/);
+    await grist.setCustomWidgetMapping('Latitude', /Latitude/);
+
+    // Click the marker to open its bound popup.
+    await grist.waitToPass(async () => {
+      await grist.inCustomWidget(async () => {
+        await grist.driver.findWait('.leaflet-marker-icon', 2000).click();
+      });
+      await grist.inCustomWidget(() => grist.driver.findWait('.leaflet-popup-content', 1000));
+    }, 10000);
+
+    // The popup shows, but DOMPurify has tidied the markup: the inline handler
+    // and any script tags are gone, so nothing runs on its own.
+    const html = (await grist.executeScriptInCustomWidget<string>(
+      () => document.querySelector('.leaflet-popup-content')?.innerHTML ?? '')).toLowerCase();
+    assert.notInclude(html, 'onerror');
+    assert.notInclude(html, '<script');
+    assert.notEqual(
+      await grist.executeScriptInCustomWidget(() => (window as any).__ran),
+      true);
+  });
+});

--- a/timeline/index.ts
+++ b/timeline/index.ts
@@ -893,6 +893,21 @@ window.onerror = function(event) {
   document.body.classList.remove('loading');
 };
 
+// Add one label/value row to the drawer, setting each piece via
+// textContent so the column label and cell value show up as plain text.
+function appendDrawerLine(drawerInfo: any, label: any, value: any) {
+  const line = document.createElement('div');
+  line.className = 'line';
+  const labelEl = document.createElement('div');
+  labelEl.className = 'label';
+  labelEl.textContent = String(label ?? '');
+  const valueEl = document.createElement('div');
+  valueEl.className = 'value';
+  valueEl.textContent = valueToString(value);
+  line.append(labelEl, valueEl);
+  drawerInfo.append(line);
+}
+
 eventGroupInfo.subscribe(openGroupDrawer);
 function openGroupDrawer(groupId: number) {
   if (!groupId) {
@@ -915,10 +930,7 @@ function openGroupDrawer(groupId: number) {
   const obj = zip(labels, values);
 
   for (const [label, value] of obj) {
-    drawerInfo.innerHTML += `<div class="line">
-    <div class="label">${label}</div>
-    <div class="value">${valueToString(value)}<div>
-    </div>`;
+    appendDrawerLine(drawerInfo, label, value);
   }
   drawer.show();
 }
@@ -939,10 +951,7 @@ function openItemDrawer(itemId: number) {
   }
   const obj = zip(itemInfo, item.data.ItemInfo ?? []);
   for (const [label, value] of obj) {
-    drawerInfo.innerHTML += `<div class="line">
-    <div class="label">${label}</div>
-    <div class="value">${valueToString(value)}<div>
-    </div>`;
+    appendDrawerLine(drawerInfo, label, value);
   }
   drawer.show();
 }

--- a/timeline/out/index.js
+++ b/timeline/out/index.js
@@ -53242,6 +53242,18 @@ input.vis-configuration.vis-config-range:focus::-ms-fill-upper {
     showAlert("danger", message);
     document.body.classList.remove("loading");
   };
+  function appendDrawerLine(drawerInfo, label, value) {
+    const line = document.createElement("div");
+    line.className = "line";
+    const labelEl = document.createElement("div");
+    labelEl.className = "label";
+    labelEl.textContent = String(label ?? "");
+    const valueEl = document.createElement("div");
+    valueEl.className = "value";
+    valueEl.textContent = valueToString(value);
+    line.append(labelEl, valueEl);
+    drawerInfo.append(line);
+  }
   eventGroupInfo.subscribe(openGroupDrawer);
   function openGroupDrawer(groupId) {
     if (!groupId) {
@@ -53260,10 +53272,7 @@ input.vis-configuration.vis-config-range:focus::-ms-fill-upper {
     const values3 = [...item.data.GroupInfo ?? [], ...item.data.Columns ?? []];
     const obj = zip(labels, values3);
     for (const [label, value] of obj) {
-      drawerInfo.innerHTML += `<div class="line">
-    <div class="label">${label}</div>
-    <div class="value">${valueToString(value)}<div>
-    </div>`;
+      appendDrawerLine(drawerInfo, label, value);
     }
     drawer.show();
   }
@@ -53281,10 +53290,7 @@ input.vis-configuration.vis-config-range:focus::-ms-fill-upper {
     }
     const obj = zip(itemInfo, item.data.ItemInfo ?? []);
     for (const [label, value] of obj) {
-      drawerInfo.innerHTML += `<div class="line">
-    <div class="label">${label}</div>
-    <div class="value">${valueToString(value)}<div>
-    </div>`;
+      appendDrawerLine(drawerInfo, label, value);
     }
     drawer.show();
   }


### PR DESCRIPTION
A few widgets were dropping cell values straight onto the page as HTML. Usually that's harmless, but it means a stray "<" or a snippet of markup in a label could show up in surprising ways instead of as the text someone actually typed. This nudges them to show text as text.

- Map: popup labels now go through DOMPurify before they're shown (Leaflet treats popup content as HTML).
- Flashcards: the question and answer are set with textContent, and a list-style answer becomes a simple bullet list.
- Timeline: the detail drawer builds its rows as DOM nodes with textContent rather than gluing together an HTML string.

Adds a couple of browser tests (Map and Flashcards) that feed in a label containing some HTML and check it shows up as plain text, and rebuilds the Timeline bundle.