### PR TITLE
Render inspect error and exoplanet greeting as text

### DIFF
--- a/exoplanet/birthday.js
+++ b/exoplanet/birthday.js
@@ -24,7 +24,7 @@ function greeting(data) {
 
 function showTable(data) {
   var msg = greeting(data);
-  $$('greeting').innerHTML = msg;
+  $$('greeting').textContent = msg;
   if (msg) {
     $$('cake').style.display = 'block';
   } else {

--- a/inspect/api.js
+++ b/inspect/api.js
@@ -111,7 +111,7 @@ function buildOutput(form, jsModel) {
         }
       } catch (err) {
         purge(jsonView);
-        jsonView.innerHTML = err.message;
+        jsonView.textContent = err.message;
       }
     }
     void run();


### PR DESCRIPTION
Both write plain text through innerHTML for no reason: inspect/api.js shows an error message, and exoplanet shows a greeting built from a record's name. Use textContent. Same cleanup as #225, for the two spots it didn't cover.