### PR TITLE
Switch to OSM tiles by default (?)

### DIFF
--- a/map/page.js
+++ b/map/page.js
@@ -8,8 +8,8 @@ let selectedTableId = null;
 let selectedRowId = null;
 let selectedRecords = null;
 let mode = 'multi';
-let mapSource = 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}';
-let mapCopyright = 'Tiles &copy; Esri &mdash; Source: Esri, DeLorme, NAVTEQ, USGS, Intermap, iPC, NRCAN, Esri Japan, METI, Esri China (Hong Kong), Esri (Thailand), TomTom, 2012';
+let mapSource = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
+let mapCopyright = '&copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>';
 // Required, Label value
 const Name = "Name";
 // Required


### PR DESCRIPTION
A user (ecouillard) asked us why we don't provide tiles from OSM for the Map widget by default:
https://forum.grist.libre.sh/t/widget-carte-possibilite-dafficher-le-fond-de-carte-plan-ign/3873/2?u=florent.fayolle

While experimenting the use of OSM, I felt like the latter is slightly smoother to load tiles (for example while playing with the zoom) than the current service (arcgisonline).
Both don't display the same elements, but I feel like it's okay-ish? (and I like the look-and-feel as well as the details from OSM).

If this PR does not retain your attention, I would be very curious to understand the motivations for choosing arcgisonline :)

## Before (with arcgisonline)

<img width="1384" height="633" alt="Map using arcgisonline.com" src="https://github.com/user-attachments/assets/23d05336-ccd3-46bf-928b-73e9fa2187fe" />


## After (using OSM)

<img width="1384" height="633" alt="Map widget using OSM" src="https://github.com/user-attachments/assets/b2c9ce11-a491-40dc-a0f5-acafaf299050" />
