### PR TITLE
fix(calendar): correct mistyped toastui template keys so translations apply

### DIFF
--- a/calendar/page.js
+++ b/calendar/page.js
@@ -187,7 +187,7 @@ class CalendarHandler {
         popupDelete(){
           return t('Delete')
         },
-        poupSave(){
+        popupSave(){
           return t('Save')
         },
         popupEdit(){
@@ -196,7 +196,7 @@ class CalendarHandler {
         popupUpdate(){
           return t('Update')
         },
-        allDayTitle() {
+        alldayTitle() {
           return t('All Day')
         },
         popupIsAllday() {

--- a/calendar/screen.css
+++ b/calendar/screen.css
@@ -93,6 +93,19 @@ body {
   height: 100%;
 }
 
+/* toastui wraps a *string* template return in a `.template-alldayTitle` span
+   instead of merging the class onto our node (as it does for its own default
+   vnode), so the library's built-in `.left-content` cell styling never reaches
+   our translated "All Day" label. Re-apply that styling to the wrapper so the
+   label keeps the default small size and stays vertically centered in the
+   all-day panel. */
+.toastui-calendar-panel-title .toastui-calendar-template-alldayTitle {
+  display: table-cell;
+  font-size: 11px;
+  text-align: right;
+  vertical-align: middle;
+}
+
 /*** BEGIN popup-related styling ***/
 
 /* On an event-view card, hide "detail" sections, since we have nothing to show there */

--- a/calendar/screen.css
+++ b/calendar/screen.css
@@ -93,17 +93,19 @@ body {
   height: 100%;
 }
 
-/* toastui wraps a *string* template return in a `.template-alldayTitle` span
-   instead of merging the class onto our node (as it does for its own default
-   vnode), so the library's built-in `.left-content` cell styling never reaches
-   our translated "All Day" label. Re-apply that styling to the wrapper so the
-   label keeps the default small size and stays vertically centered in the
-   all-day panel. */
+/* toastui renders a string template inside a fresh `.template-alldayTitle` span
+   without its default `.left-content` styling, so re-apply it here. The cell is
+   pinned to the 72px hour-gutter width but laid out as `display: table`, where
+   that width is only a minimum: a nowrap label longer than "All day" (e.g.
+   "Toute la journée") widens it and shifts the all-day row right, so let the
+   label wrap to keep the columns aligned. */
 .toastui-calendar-panel-title .toastui-calendar-template-alldayTitle {
   display: table-cell;
   font-size: 11px;
+  line-height: 1.15;
   text-align: right;
   vertical-align: middle;
+  white-space: normal;
 }
 
 /*** BEGIN popup-related styling ***/


### PR DESCRIPTION
Two template callbacks in the calendar widget were registered under **misspelled keys**, so toastui-calendar never invoked them and rendered its hardcoded English labels:

- `poupSave` → `popupSave` (event popup "Save" button)
- `allDayTitle` → `alldayTitle` (week/day all-day row label)

The i18next keys (`t('Save')`, `t('All Day')`) already existed in every populated translation file; only the template names were wrong. Bug present since #65.

**Follow-up (2nd commit):** once `alldayTitle` fires, it returns a *string*, which toastui wraps in a bare `.template-alldayTitle` element (it only merges the class onto its own default *vnode*). That dropped the built-in `.left-content` cell styling, leaving the label oversized and top-aligned. A CSS rule re-applies `display:table-cell; font-size:11px; text-align:right; vertical-align:middle` to the wrapper, restoring the default look — now translated.
